### PR TITLE
Support Cisco

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Subcommands for fetch-alpine:
 Subcommands for fetch-amazon:
         fetch-amazon     Fetch Vulnerability dictionary from Amazon ALAS
 
+Subcommands for fetch-cisco:
+        fetch-cisco      Fetch Vulnerability dictionary from Cisco
+
 Subcommands for fetch-debian:
         fetch-debian     Fetch Vulnerability dictionary from Debian
 

--- a/commands/fetch-cisco.go
+++ b/commands/fetch-cisco.go
@@ -1,0 +1,173 @@
+package commands
+
+import (
+	"context"
+	"encoding/xml"
+	"flag"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/subcommands"
+	"github.com/inconshreveable/log15"
+	c "github.com/kotakanbe/goval-dictionary/config"
+	"github.com/kotakanbe/goval-dictionary/db"
+	"github.com/kotakanbe/goval-dictionary/fetcher"
+	"github.com/kotakanbe/goval-dictionary/models"
+	"github.com/kotakanbe/goval-dictionary/util"
+	"github.com/ymomoi/goval-parser/oval"
+)
+
+// FetchCiscoCmd is Subcommand for fetch Cisco OVAL
+type FetchCiscoCmd struct {
+	Debug     bool
+	DebugSQL  bool
+	Quiet     bool
+	NoDetails bool
+	LogDir    string
+	LogJSON   bool
+	DBPath    string
+	DBType    string
+	HTTPProxy string
+}
+
+// Name return subcommand name
+func (*FetchCiscoCmd) Name() string { return "fetch-cisco" }
+
+// Synopsis return synopsis
+func (*FetchCiscoCmd) Synopsis() string { return "Fetch Vulnerability dictionary from Cisco" }
+
+// Usage return usage
+func (*FetchCiscoCmd) Usage() string {
+	return `fetch-cisco:
+	fetch-cisco
+		[-dbtype=sqlite3|mysql|postgres|redis]
+		[-dbpath=$PWD/oval.sqlite3 or connection string]
+		[-http-proxy=http://192.168.0.1:8080]
+		[-debug]
+		[-debug-sql]
+		[-quiet]
+		[-no-details]
+		[-log-dir=/path/to/log]
+		[-log-json]
+
+For the first time, run the blow command to fetch data for all versions.
+	$ goval-dictionary fetch-cisco asa ios ios_xe pix
+
+`
+}
+
+// SetFlags set flag
+func (p *FetchCiscoCmd) SetFlags(f *flag.FlagSet) {
+	f.BoolVar(&p.Debug, "debug", false, "debug mode")
+	f.BoolVar(&p.DebugSQL, "debug-sql", false, "SQL debug mode")
+	f.BoolVar(&p.Quiet, "quiet", false, "quiet mode (no output)")
+	f.BoolVar(&p.NoDetails, "no-details", false, "without vulnerability details")
+
+	defaultLogDir := util.GetDefaultLogDir()
+	f.StringVar(&p.LogDir, "log-dir", defaultLogDir, "/path/to/log")
+	f.BoolVar(&p.LogJSON, "log-json", false, "output log as JSON")
+
+	pwd := os.Getenv("PWD")
+	f.StringVar(&p.DBPath, "dbpath", pwd+"/oval.sqlite3",
+		"/path/to/sqlite3 or SQL connection string")
+
+	f.StringVar(&p.DBType, "dbtype", "sqlite3",
+		"Database type to store data in (sqlite3, mysql, postgres or redis supported)")
+
+	f.StringVar(
+		&p.HTTPProxy,
+		"http-proxy",
+		"",
+		"http://proxy-url:port (default: empty)",
+	)
+}
+
+// Execute execute
+func (p *FetchCiscoCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	c.Conf.Quiet = p.Quiet
+	c.Conf.DebugSQL = p.DebugSQL
+	c.Conf.Debug = p.Debug
+	c.Conf.DBPath = p.DBPath
+	c.Conf.DBType = p.DBType
+	c.Conf.HTTPProxy = p.HTTPProxy
+	c.Conf.NoDetails = p.NoDetails
+
+	util.SetLogger(p.LogDir, c.Conf.Quiet, c.Conf.Debug, p.LogJSON)
+	if !c.Conf.Validate() {
+		return subcommands.ExitUsageError
+	}
+
+	if len(f.Args()) == 0 {
+		log15.Error("Specify versions to fetch")
+		return subcommands.ExitUsageError
+	}
+
+	driver, locked, err := db.NewDB(c.Cisco, c.Conf.DBType, c.Conf.DBPath, c.Conf.DebugSQL)
+	if err != nil {
+		if locked {
+			log15.Error("Failed to open DB. Close DB connection before fetching", "err", err)
+			return subcommands.ExitFailure
+		}
+		log15.Error("Failed to open DB", "err", err)
+		return subcommands.ExitFailure
+	}
+
+	// Distinct
+	v := map[string]bool{}
+	vers := []string{}
+	for _, arg := range f.Args() {
+		v[arg] = true
+	}
+	for k := range v {
+		vers = append(vers, k)
+	}
+
+	results, err := fetcher.FetchCiscoFiles(vers)
+	if err != nil {
+		log15.Error("Failed to fetch files", "err", err)
+		return subcommands.ExitFailure
+	}
+
+	for _, r := range results {
+		ovalroot := oval.Root{}
+		if err = xml.Unmarshal(r.Body, &ovalroot); err != nil {
+			log15.Error("Failed to unmarshal", "url", r.URL, "err", err)
+			log15.Error("Failed to unmarshal", "body", r.Body)
+			return subcommands.ExitUsageError
+		}
+		log15.Info("Fetched", "URL", r.URL, "OVAL definitions", len(ovalroot.Definitions.Definitions))
+
+		defs := models.ConvertCiscoToModel(&ovalroot)
+
+		var timeformat = "2006-01-02T15:04:05"
+		t, err := time.Parse(timeformat, ovalroot.Generator.Timestamp)
+		if err != nil {
+			panic(err)
+		}
+
+		root := models.Root{
+			Family:      c.Cisco,
+			OSVersion:   r.Target,
+			Definitions: defs,
+			Timestamp:   time.Now(),
+		}
+
+		ss := strings.Split(r.URL, "/")
+		fmeta := models.FetchMeta{
+			Timestamp: t,
+			FileName:  ss[len(ss)-1],
+		}
+
+		if err := driver.InsertOval(&root, fmeta); err != nil {
+			log15.Error("Failed to insert OVAL", "err", err)
+			return subcommands.ExitFailure
+		}
+		if err := driver.InsertFetchMeta(fmeta); err != nil {
+			log15.Error("Failed to insert meta", "err", err)
+			return subcommands.ExitFailure
+		}
+	}
+
+	return subcommands.ExitSuccess
+}

--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,9 @@ const (
 
 	// Amazon is
 	Amazon = "amazon"
+
+	// Cisco is
+	Cisco = "cisco"
 )
 
 // Conf has Configuration

--- a/db/rdb/cisco.go
+++ b/db/rdb/cisco.go
@@ -174,9 +174,7 @@ func (o *Cisco) GetByCveID(osVer, cveID string, driver *gorm.DB) ([]models.Defin
 		if err != nil && err != gorm.ErrRecordNotFound {
 			return nil, err
 		}
-
-		// Cisco has no version information
-		if root.Family == config.Cisco {
+		if root.Family == config.Cisco && major(root.OSVersion) == osVer {
 			defs = append(defs, def)
 		}
 	}

--- a/db/rdb/cisco.go
+++ b/db/rdb/cisco.go
@@ -1,0 +1,207 @@
+package rdb
+
+import (
+	"fmt"
+
+	"github.com/inconshreveable/log15"
+	"github.com/jinzhu/gorm"
+	"github.com/k0kubun/pp"
+	"github.com/kotakanbe/goval-dictionary/config"
+	"github.com/kotakanbe/goval-dictionary/models"
+)
+
+// Cisco is a struct for DBAccess
+type Cisco struct {
+	Family string
+}
+
+// NewCisco creates DBAccess
+func NewCisco() *Cisco {
+	return &Cisco{Family: config.Cisco}
+}
+
+// Name return family name
+func (o *Cisco) Name() string {
+	return o.Family
+}
+
+// InsertOval inserts Cisco OVAL
+func (o *Cisco) InsertOval(root *models.Root, meta models.FetchMeta, driver *gorm.DB) error {
+	log15.Debug("in Cisco")
+	tx := driver.Begin()
+
+	oldmeta := models.FetchMeta{}
+	r := tx.Where(&models.FetchMeta{FileName: meta.FileName}).First(&oldmeta)
+	if !r.RecordNotFound() && oldmeta.Timestamp.Equal(meta.Timestamp) {
+		log15.Info("Skip (Same Timestamp)", "Family", root.Family, "Version", root.OSVersion)
+		return tx.Rollback().Error
+	}
+	log15.Info("Refreshing...", "Family", root.Family, "Version", root.OSVersion)
+
+	old := models.Root{}
+	r = tx.Where(&models.Root{Family: root.Family, OSVersion: root.OSVersion}).First(&old)
+	if !r.RecordNotFound() {
+		// Delete data related to root passed in arg
+		defs := []models.Definition{}
+		tx.Model(&old).Related(&defs, "Definitions")
+		for _, def := range defs {
+			deb := models.Debian{}
+			tx.Model(&def).Related(&deb, "Debian")
+			if err := tx.Unscoped().Where("definition_id = ?", def.ID).Delete(&models.Debian{}).Error; err != nil {
+				tx.Rollback()
+				return fmt.Errorf("Failed to delete: %s", err)
+			}
+			adv := models.Advisory{}
+			tx.Model(&def).Related(&adv, "Advisory")
+			if err := tx.Unscoped().Where("definition_id = ?", def.ID).Delete(&models.Advisory{}).Error; err != nil {
+				tx.Rollback()
+				return fmt.Errorf("Failed to delete: %s", err)
+			}
+			if err := tx.Unscoped().Where("definition_id= ?", def.ID).Delete(&models.Package{}).Error; err != nil {
+				tx.Rollback()
+				return fmt.Errorf("Failed to delete: %s", err)
+			}
+			if err := tx.Unscoped().Where("definition_id = ?", def.ID).Delete(&models.Reference{}).Error; err != nil {
+				tx.Rollback()
+				return fmt.Errorf("Failed to delete: %s", err)
+			}
+		}
+		if err := tx.Unscoped().Where("root_id = ?", old.ID).Delete(&models.Definition{}).Error; err != nil {
+			tx.Rollback()
+			return fmt.Errorf("Failed to delete: %s", err)
+		}
+		if err := tx.Unscoped().Where("id = ?", old.ID).Delete(&models.Root{}).Error; err != nil {
+			tx.Rollback()
+			return fmt.Errorf("Failed to delete: %s", err)
+		}
+	}
+
+	if err := tx.Create(&root).Error; err != nil {
+		tx.Rollback()
+		return fmt.Errorf("Failed to insert. cve: %s, err: %s",
+			pp.Sprintf("%v", root), err)
+	}
+
+	return tx.Commit().Error
+}
+
+// GetByPackName select definitions by packName
+func (o *Cisco) GetByPackName(osVer, packName string, driver *gorm.DB) ([]models.Definition, error) {
+	osVer = major(osVer)
+	packs := []models.Package{}
+	err := driver.Where(&models.Package{Name: packName}).Find(&packs).Error
+	if err != nil && err != gorm.ErrRecordNotFound {
+		return nil, err
+	}
+
+	defs := []models.Definition{}
+	for _, p := range packs {
+		def := models.Definition{}
+		err = driver.Where("id = ?", p.DefinitionID).Find(&def).Error
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+
+		root := models.Root{}
+		err = driver.Where("id = ?", def.RootID).Find(&root).Error
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+
+		if root.Family == config.Cisco && major(root.OSVersion) == osVer {
+			defs = append(defs, def)
+		}
+	}
+
+	for i, def := range defs {
+		deb := models.Debian{}
+		err = driver.Model(&def).Related(&deb, "Debian").Error
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+		defs[i].Debian = deb
+
+		adv := models.Advisory{}
+		err = driver.Model(&def).Related(&adv, "Advisory").Error
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+		defs[i].Advisory = adv
+
+		packs := []models.Package{}
+		err = driver.Model(&def).Related(&packs, "AffectedPacks").Error
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+		defs[i].AffectedPacks = packs
+
+		refs := []models.Reference{}
+		err = driver.Model(&def).Related(&refs, "References").Error
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+		defs[i].References = refs
+	}
+
+	return defs, nil
+}
+
+// GetByCveID select definitions by CveID
+func (o *Cisco) GetByCveID(osVer, cveID string, driver *gorm.DB) ([]models.Definition, error) {
+	osVer = major(osVer)
+
+	refs := []models.Reference{}
+	err := driver.Where(&models.Reference{Source: "CVE", RefID: cveID}).Find(&refs).Error
+	if err != nil && err != gorm.ErrRecordNotFound {
+		return nil, err
+	}
+
+	defs := []models.Definition{}
+	for _, ref := range refs {
+		def := models.Definition{}
+		err = driver.Where("id = ?", ref.DefinitionID).Find(&def).Error
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+
+		root := models.Root{}
+		err = driver.Where("id = ?", def.RootID).Find(&root).Error
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+		if root.Family == config.Cisco && major(root.OSVersion) == osVer {
+			defs = append(defs, def)
+		}
+	}
+
+	for i, def := range defs {
+		deb := models.Debian{}
+		err = driver.Model(&def).Related(&deb, "Debian").Error
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+		defs[i].Debian = deb
+
+		adv := models.Advisory{}
+		err = driver.Model(&def).Related(&adv, "Advisory").Error
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+		defs[i].Advisory = adv
+
+		packs := []models.Package{}
+		err = driver.Model(&def).Related(&packs, "AffectedPacks").Error
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+		defs[i].AffectedPacks = packs
+
+		refs := []models.Reference{}
+		err = driver.Model(&def).Related(&refs, "References").Error
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+		defs[i].References = refs
+	}
+	return defs, nil
+}

--- a/db/rdb/rdb.go
+++ b/db/rdb/rdb.go
@@ -78,6 +78,8 @@ func (d *Driver) NewOvalDB(family string) error {
 		d.ovaldb = NewAlpine()
 	case c.Amazon:
 		d.ovaldb = NewAmazon()
+	case c.Cisco:
+		d.ovaldb = NewCisco()
 	default:
 		if strings.Contains(family, "suse") {
 			suses := []string{

--- a/fetcher/cisco.go
+++ b/fetcher/cisco.go
@@ -1,0 +1,33 @@
+package fetcher
+
+import (
+	"fmt"
+)
+
+func newCiscoFetchRequests(target []string) (reqs []fetchRequest) {
+	const t = "https://oval.cisecurity.org/repository/download/5.11.2/vulnerability/cisco_%s.xml"
+	for _, v := range target {
+		reqs = append(reqs, fetchRequest{
+			target:       v,
+			url:          fmt.Sprintf(t, v),
+			bzip2:        false,
+			concurrently: false,
+		})
+	}
+	return
+}
+
+// FetchCiscoFiles fetch OVAL from Cisco
+func FetchCiscoFiles(versions []string) ([]FetchResult, error) {
+	reqs := newCiscoFetchRequests(versions)
+	if len(reqs) == 0 {
+		return nil,
+			fmt.Errorf("There are no versions to fetch")
+	}
+	results, err := fetchFeedFiles(reqs)
+	if err != nil {
+		return nil,
+			fmt.Errorf("Failed to fetch. err: %s", err)
+	}
+	return results, nil
+}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 	subcommands.Register(&commands.FetchOracleCmd{}, "fetch-oracle")
 	subcommands.Register(&commands.FetchAlpineCmd{}, "fetch-alpine")
 	subcommands.Register(&commands.FetchAmazonCmd{}, "fetch-amazon")
+	subcommands.Register(&commands.FetchCiscoCmd{}, "fetch-cisco")
 	subcommands.Register(&commands.SelectCmd{}, "select")
 	subcommands.Register(&commands.ServerCmd{}, "server")
 

--- a/models/cisco.go
+++ b/models/cisco.go
@@ -24,30 +24,15 @@ func ConvertCiscoToModel(root *oval.Root) (defs []Definition) {
 			}
 		}
 
-		for _, r := range d.Advisory.Refs {
-			rs = append(rs, Reference{
-				Source: "Ref",
-				RefURL: r.URL,
-			})
-		}
-
-		for _, r := range d.Advisory.Bugs {
-			rs = append(rs, Reference{
-				Source: "Bug",
-				RefURL: r.URL,
-			})
-		}
-
 		def := Definition{
 			DefinitionID: d.ID,
 			Title:        d.Title,
 			Description:  d.Description,
 			Advisory: Advisory{
-				Severity: d.Advisory.Severity,
+				Cves: []Cve{{CveID: cveID}},
 			},
-			Debian:        Debian{CveID: cveID},
+			References: rs,
 			AffectedPacks: collectCiscoPacks(d.Criteria),
-			References:    rs,
 		}
 
 		if c.Conf.NoDetails {
@@ -82,7 +67,7 @@ func walkCisco(cri oval.Criteria, acc []Package) []Package {
 		return acc
 	}
 	for _, c := range cri.Criterias {
-		acc = walkRedHat(c, acc)
+		acc = walkCisco(c, acc)
 	}
 	return acc
 }

--- a/models/cisco.go
+++ b/models/cisco.go
@@ -1,0 +1,88 @@
+package models
+
+import (
+	"strings"
+
+	c "github.com/kotakanbe/goval-dictionary/config"
+	"github.com/ymomoi/goval-parser/oval"
+)
+
+// ConvertCiscoToModel Convert OVAL to models
+func ConvertCiscoToModel(root *oval.Root) (defs []Definition) {
+	for _, d := range root.Definitions.Definitions {
+
+		cveID := ""
+		rs := []Reference{}
+		for _, r := range d.References {
+			rs = append(rs, Reference{
+				Source: r.Source,
+				RefID:  r.RefID,
+				RefURL: r.RefURL,
+			})
+			if r.Source == "CVE" {
+				cveID = r.RefID
+			}
+		}
+
+		for _, r := range d.Advisory.Refs {
+			rs = append(rs, Reference{
+				Source: "Ref",
+				RefURL: r.URL,
+			})
+		}
+
+		for _, r := range d.Advisory.Bugs {
+			rs = append(rs, Reference{
+				Source: "Bug",
+				RefURL: r.URL,
+			})
+		}
+
+		def := Definition{
+			DefinitionID: d.ID,
+			Title:        d.Title,
+			Description:  d.Description,
+			Advisory: Advisory{
+				Severity: d.Advisory.Severity,
+			},
+			Debian:        Debian{CveID: cveID},
+			AffectedPacks: collectCiscoPacks(d.Criteria),
+			References:    rs,
+		}
+
+		if c.Conf.NoDetails {
+			def.Title = ""
+			def.Description = ""
+			def.Advisory = Advisory{}
+			def.References = []Reference{}
+		}
+
+		defs = append(defs, def)
+	}
+	return
+}
+
+func collectCiscoPacks(cri oval.Criteria) []Package {
+	return walkCisco(cri, []Package{})
+}
+
+func walkCisco(cri oval.Criteria, acc []Package) []Package {
+	for _, c := range cri.Criterions {
+		ss := strings.Split(c.Comment, " is earlier than ")
+		if len(ss) != 2 {
+			continue
+		}
+		acc = append(acc, Package{
+			Name:    ss[0],
+			Version: strings.Split(ss[1], " ")[0],
+		})
+	}
+
+	if len(cri.Criterias) == 0 {
+		return acc
+	}
+	for _, c := range cri.Criterias {
+		acc = walkRedHat(c, acc)
+	}
+	return acc
+}


### PR DESCRIPTION
I quick hacked for support cisco.
I did not enough test yet.
I checked some tables created.

```
% ./goval-dictionary fetch-cisco asa ios ios_xe pix
INFO[06-08|22:03:50] Fetching...                              URL=https://oval.cisecurity.org/repository/download/5.11.2/vulnerability/cisco_asa.xml
INFO[06-08|22:03:50] Fetching...                              URL=https://oval.cisecurity.org/repository/download/5.11.2/vulnerability/cisco_ios.xml
INFO[06-08|22:03:50] Fetching...                              URL=https://oval.cisecurity.org/repository/download/5.11.2/vulnerability/cisco_ios_xe.xml
INFO[06-08|22:03:50] Fetching...                              URL=https://oval.cisecurity.org/repository/download/5.11.2/vulnerability/cisco_pix.xml
INFO[06-08|22:03:54] Fetched...                               URL=https://oval.cisecurity.org/repository/download/5.11.2/vulnerability/cisco_pix.xml
INFO[06-08|22:03:54] Fetched...                               URL=https://oval.cisecurity.org/repository/download/5.11.2/vulnerability/cisco_ios_xe.xml
INFO[06-08|22:03:54] Fetched...                               URL=https://oval.cisecurity.org/repository/download/5.11.2/vulnerability/cisco_asa.xml
INFO[06-08|22:03:54] Fetched...                               URL=https://oval.cisecurity.org/repository/download/5.11.2/vulnerability/cisco_ios.xml
INFO[06-08|22:03:54] Finished fetching OVAL definitions 
INFO[06-08|22:03:54] Fetched                                  URL=https://oval.cisecurity.org/repository/download/5.11.2/vulnerability/cisco_pix.xml OVAL definitions=3
INFO[06-08|22:03:54] Refreshing...                            Family=cisco Version=pix
INFO[06-08|22:03:54] Fetched                                  URL=https://oval.cisecurity.org/repository/download/5.11.2/vulnerability/cisco_ios_xe.xml OVAL definitions=189
INFO[06-08|22:03:54] Refreshing...                            Family=cisco Version=ios_xe
INFO[06-08|22:03:54] Fetched                                  URL=https://oval.cisecurity.org/repository/download/5.11.2/vulnerability/cisco_asa.xml OVAL definitions=14
INFO[06-08|22:03:54] Refreshing...                            Family=cisco Version=asa
INFO[06-08|22:03:55] Fetched                                  URL=https://oval.cisecurity.org/repository/download/5.11.2/vulnerability/cisco_ios.xml OVAL definitions=457
INFO[06-08|22:03:55] Refreshing...                            Family=cisco Version=ios

% sqlite3 oval.sqlite3
sqlite> select * from roots ;
1|cisco|pix|2019-06-08 22:03:54.757755+09:00
2|cisco|ios_xe|2019-06-08 22:03:54.800865+09:00
3|cisco|asa|2019-06-08 22:03:54.829995+09:00
4|cisco|ios|2019-06-08 22:03:55.00476+09:00
sqlite> select count(*) from definitions ;
663
sqlite> select * from definitions limit 1;
id|root_id|definition_id|title|description
1|1|oval:org.mitre.oval:def:5983|Cisco PIX and ASA Windows NT Domain Authentication Bypass Vulnerability|Unspecified vulnerability in Cisco Adaptive Security Appliances (ASA) 5500 Series and PIX Security Appliances 7.0 before 7.0(8)3, 7.1 before 7.1(2)78, 7.2 before 7.2(4)16, 8.0 before 8.0(4)6, and 8.1 before 8.1(1)13, when configured as a VPN using Microsoft Windows NT Domain authentication, allows remote attackers to bypass VPN authentication via unknown vectors.
sqlite> select * from definitions order by id desc limit 1;
id|root_id|definition_id|title|description
663|4|oval:org.mitre.oval:def:5461|Cisco IOS 12.0 Turbo ACL Denial of Service Vulnerability|Cisco 12000 with IOS 12.0 and line cards based on Engine 2 does not support the "fragment" keyword in an outgoing ACL, which could allow fragmented packets in violation of the intended access.
sqlite> select count(*) from cves ;
count(*)
0
```