### PR TITLE
chore(linter): change linter from golint to revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,19 +1,49 @@
 name: golang-ci
 
 linters-settings:
-  errcheck:
+  revive:
+    # see https://github.com/mgechev/revive#available-rules for details.
+    ignore-generated-header: true
+    severity: warning
+    confidence: 0.8
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+  # errcheck:
     #exclude: /path/to/file.txt
-    #  misspell:
-    #ignore-words:
-    #  - Criterias
+  misspell:
+    ignore-words:
+     - criterias
 
 linters:
   disable-all: true
   enable:
     - goimports
-    - golint
+    - revive
     - govet
-      #- misspell
+    - misspell
     - errcheck
     - staticcheck
     - prealloc

--- a/.revive.toml
+++ b/.revive.toml
@@ -1,0 +1,30 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+[rule.blank-imports]
+[rule.context-as-argument]
+[rule.context-keys-type]
+[rule.dot-imports]
+[rule.error-return]
+[rule.error-strings]
+[rule.error-naming]
+[rule.exported]
+[rule.if-return]
+[rule.increment-decrement]
+[rule.var-naming]
+[rule.var-declaration]
+[rule.package-comments]
+[rule.range]
+[rule.receiver-naming]
+[rule.time-naming]
+[rule.unexported-return]
+[rule.indent-error-flow]
+[rule.errorf]
+[rule.empty-block]
+[rule.superfluous-else]
+[rule.unused-parameter]
+[rule.unreachable-code]
+[rule.redefines-builtin-id]

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,11 +1,10 @@
 .PHONY: \
+	all \
 	build \
 	install \
-	all \
-	vendor \
+	lint \
 	vet \
 	fmt \
-	fmtcheck \
 	pretest \
 	test \
 	cov \
@@ -40,6 +39,10 @@ b: 	main.go pretest
 install: main.go pretest
 	$(GO) install -ldflags "$(LDFLAGS)"
 
+lint:
+	$(GO_OFF) get -u github.com/mgechev/revive
+	revive -config ./.revive.toml -formatter plain $(PKGS)
+
 vet:
 	echo $(PKGS) | xargs env $(GO) vet || exit;
 
@@ -52,9 +55,9 @@ mlint:
 fmtcheck:
 	$(foreach file,$(SRCS),gofmt -s -d $(file);)
 
-pretest: vet fmtcheck
+pretest: lint vet fmtcheck
 
-test: 
+test: pretest
 	$(GO) test -cover -v ./... || exit;
 
 unused:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,8 +5,11 @@
 	lint \
 	vet \
 	fmt \
+	mlint \
+	fmtcheck \
 	pretest \
 	test \
+	unused \
 	cov \
 	clean \
 	build-integration \

--- a/commands/fetch-alpine.go
+++ b/commands/fetch-alpine.go
@@ -31,7 +31,7 @@ func init() {
 	fetchCmd.AddCommand(fetchAlpineCmd)
 }
 
-func fetchAlpine(cmd *cobra.Command, args []string) (err error) {
+func fetchAlpine(_ *cobra.Command, args []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/fetch-amazon.go
+++ b/commands/fetch-amazon.go
@@ -28,7 +28,7 @@ func init() {
 	fetchCmd.AddCommand(fetchAmazonCmd)
 }
 
-func fetchAmazon(cmd *cobra.Command, args []string) (err error) {
+func fetchAmazon(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/fetch-debian.go
+++ b/commands/fetch-debian.go
@@ -30,7 +30,7 @@ func init() {
 	fetchCmd.AddCommand(fetchDebianCmd)
 }
 
-func fetchDebian(cmd *cobra.Command, args []string) (err error) {
+func fetchDebian(_ *cobra.Command, args []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/fetch-oracle.go
+++ b/commands/fetch-oracle.go
@@ -28,7 +28,7 @@ func init() {
 	fetchCmd.AddCommand(fetchOracleCmd)
 }
 
-func fetchOracle(cmd *cobra.Command, args []string) (err error) {
+func fetchOracle(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/fetch-redhat.go
+++ b/commands/fetch-redhat.go
@@ -29,7 +29,7 @@ func init() {
 	fetchCmd.AddCommand(fetchRedHatCmd)
 }
 
-func fetchRedHat(cmd *cobra.Command, args []string) (err error) {
+func fetchRedHat(_ *cobra.Command, args []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/fetch-suse.go
+++ b/commands/fetch-suse.go
@@ -39,7 +39,7 @@ func init() {
 	_ = viper.BindPFlag("suse-type", fetchSUSECmd.PersistentFlags().Lookup("suse-type"))
 }
 
-func fetchSUSE(cmd *cobra.Command, args []string) (err error) {
+func fetchSUSE(_ *cobra.Command, args []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/fetch-ubuntu.go
+++ b/commands/fetch-ubuntu.go
@@ -28,7 +28,7 @@ func init() {
 	fetchCmd.AddCommand(fetchUbuntuCmd)
 }
 
-func fetchUbuntu(cmd *cobra.Command, args []string) (err error) {
+func fetchUbuntu(_ *cobra.Command, args []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/select.go
+++ b/commands/select.go
@@ -31,7 +31,7 @@ func init() {
 	_ = viper.BindPFlag("by-cveid", selectCmd.PersistentFlags().Lookup("by-cveid"))
 }
 
-func executeSelect(cmd *cobra.Command, args []string) error {
+func executeSelect(_ *cobra.Command, args []string) error {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/commands/server.go
+++ b/commands/server.go
@@ -29,7 +29,7 @@ func init() {
 	_ = viper.BindPFlag("port", serverCmd.PersistentFlags().Lookup("port"))
 }
 
-func executeServer(cmd *cobra.Command, args []string) (err error) {
+func executeServer(_ *cobra.Command, _ []string) (err error) {
 	if err := util.SetLogger(viper.GetBool("log-to-file"), viper.GetString("log-dir"), viper.GetBool("debug"), viper.GetBool("log-json")); err != nil {
 		return xerrors.Errorf("Failed to SetLogger. err: %w", err)
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -28,6 +28,7 @@ type DB interface {
 	GetLastModified(string, string) (time.Time, error)
 }
 
+// Option :
 type Option struct {
 	RedisTimeout time.Duration
 }

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -42,7 +42,7 @@ func (r *RDBDriver) Name() string {
 }
 
 // OpenDB opens Database
-func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool, option Option) (locked bool, err error) {
+func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool, _ Option) (locked bool, err error) {
 	gormConfig := gorm.Config{
 		DisableForeignKeyConstraintWhenMigrating: true,
 		Logger: logger.New(

--- a/db/redis.go
+++ b/db/redis.go
@@ -80,7 +80,7 @@ func (r *RedisDriver) Name() string {
 }
 
 // OpenDB opens Database
-func (r *RedisDriver) OpenDB(dbType, dbPath string, debugSQL bool, option Option) (locked bool, err error) {
+func (r *RedisDriver) OpenDB(dbType, dbPath string, _ bool, option Option) (locked bool, err error) {
 	if err := r.connectRedis(dbPath, option); err != nil {
 		return false, xerrors.Errorf("Failed to open DB. dbtype: %s, dbpath: %s, err: %w", dbType, dbPath, err)
 	}


### PR DESCRIPTION
# What did you implement:
Change the linter to revive, since golint has been deprecated as follows.
> NOTE: Golint is deprecated and frozen. There's no drop-in replacement for it, but tools such as Staticcheck and go vet should be used instead.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ make lint
$ golangci-lint run -c .golangci.yml
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

