### PR TITLE
fix(db): change fetchmeta insert order

### DIFF
--- a/commands/fetch-alpine.go
+++ b/commands/fetch-alpine.go
@@ -71,6 +71,11 @@ func fetchAlpine(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
+		return err
+	}
+
 	results, err := fetcher.FetchAlpineFiles(vers)
 	if err != nil {
 		log15.Error("Failed to fetch files", "err", err)
@@ -132,11 +137,6 @@ func fetchAlpine(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 		log15.Info("Finish", "Updated", len(root.Definitions))
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
-		return err
 	}
 
 	return nil

--- a/commands/fetch-amazon.go
+++ b/commands/fetch-amazon.go
@@ -57,6 +57,11 @@ func fetchAmazon(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
+		return err
+	}
+
 	uinfo, err := fetcher.FetchUpdateInfoAmazonLinux1()
 	if err != nil {
 		log15.Error("Failed to fetch updateinfo for Amazon Linux1", "err", err)
@@ -88,11 +93,6 @@ func fetchAmazon(cmd *cobra.Command, args []string) (err error) {
 	log15.Info(fmt.Sprintf("%d CVEs for Amazon Linux2. Inserting to DB", len(root.Definitions)))
 	if err := execute(driver, &root); err != nil {
 		log15.Error("Failed to Insert Amazon2", "err", err)
-		return err
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
 		return err
 	}
 

--- a/commands/fetch-debian.go
+++ b/commands/fetch-debian.go
@@ -62,6 +62,11 @@ func fetchDebian(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
+		return err
+	}
+
 	// Distinct
 	vers := []string{}
 	v := map[string]bool{}
@@ -118,11 +123,6 @@ func fetchDebian(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 		log15.Info("Finish", "Updated", len(root.Definitions))
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
-		return err
 	}
 
 	return nil

--- a/commands/fetch-oracle.go
+++ b/commands/fetch-oracle.go
@@ -54,6 +54,11 @@ func fetchOracle(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
+		return err
+	}
+
 	results, err := fetcher.FetchOracleFiles()
 	if err != nil {
 		log15.Error("Failed to fetch files", "err", err)
@@ -106,11 +111,6 @@ func fetchOracle(cmd *cobra.Command, args []string) (err error) {
 
 	if err := driver.InsertFileMeta(fmeta); err != nil {
 		log15.Error("Failed to insert meta", "err", err)
-		return err
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
 		return err
 	}
 

--- a/commands/fetch-redhat.go
+++ b/commands/fetch-redhat.go
@@ -60,6 +60,11 @@ func fetchRedHat(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
+		return err
+	}
+
 	// Distinct
 	vers := []string{}
 	v := map[string]bool{}
@@ -119,11 +124,6 @@ func fetchRedHat(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 		log15.Info("Finish", "Updated", len(root.Definitions))
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
-		return err
 	}
 
 	return nil

--- a/commands/fetch-suse.go
+++ b/commands/fetch-suse.go
@@ -96,6 +96,11 @@ func fetchSUSE(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
+		return err
+	}
+
 	var results []fetcher.FetchResult
 	results, err = fetcher.FetchSUSEFiles(suseType, vers)
 	if err != nil {
@@ -137,11 +142,6 @@ func fetchSUSE(cmd *cobra.Command, args []string) (err error) {
 			log15.Error("Failed to insert meta", "err", err)
 			return err
 		}
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
-		return err
 	}
 
 	return nil

--- a/commands/fetch-ubuntu.go
+++ b/commands/fetch-ubuntu.go
@@ -59,6 +59,11 @@ func fetchUbuntu(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
+		return err
+	}
+
 	// Distinct
 	v := map[string]bool{}
 	vers := []string{}
@@ -114,11 +119,6 @@ func fetchUbuntu(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 		log15.Info("Finish", "Updated", len(root.Definitions))
-	}
-
-	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
-		log15.Error("Failed to upsert FetchMeta to DB.", "err", err)
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
# What did you implement:
If an error occurs during the first fetch, it is required to clean the DB during the second Insert. 
The old data can be deleted when updating between the same schema versions.
To avoid this problem, insert FetchMeta first.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

