### PR TITLE
breaking-change(redis): deprecated expire option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Available Commands:
   ubuntu      Fetch Vulnerability dictionary from Ubuntu
 
 Flags:
-      --expire uint   timeout to set for Redis keys in seconds. If set to 0, the key is persistent.
   -h, --help          help for fetch
       --no-details    without vulnerability details
 

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -20,7 +20,4 @@ func init() {
 
 	fetchCmd.PersistentFlags().Int("batch-size", 25, "The number of batch size to insert.")
 	_ = viper.BindPFlag("batch-size", fetchCmd.PersistentFlags().Lookup("batch-size"))
-
-	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys in seconds. If set to 0, the key is persistent.")
-	_ = viper.BindPFlag("expire", fetchCmd.PersistentFlags().Lookup("expire"))
 }


### PR DESCRIPTION
# What did you implement:
Expire was introduced to ensure safe operation in Redis, but since expire can only be set per key, it is not very useful for Sets and Hash.
Therefore, if there is any old content in each fetch, it will be deleted.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

