### PR TITLE
feat: do not skip OVAL insert

### DIFF
--- a/commands/fetch-alpine.go
+++ b/commands/fetch-alpine.go
@@ -108,22 +108,9 @@ func fetchAlpine(cmd *cobra.Command, args []string) (err error) {
 			Timestamp:   time.Now(),
 		}
 
-		timestamp, err := time.Parse("2006-01-02T15:04:05Z", time.Now().Format("2006-01-02T15:04:05Z"))
-		if err != nil {
-			return xerrors.Errorf("Failed to parse timestamp. url: %s, err: %w", t.url, err)
-		}
-
-		fmeta := models.FileMeta{
-			Timestamp: timestamp,
-			FileName:  t.url,
-		}
-
 		log15.Info(fmt.Sprintf("%d CVEs", len(t.defs)))
-		if err := driver.InsertOval(&root, fmeta); err != nil {
-			return xerrors.Errorf("Failed to insert meta. err: %w", err)
-		}
-		if err := driver.InsertFileMeta(fmeta); err != nil {
-			return xerrors.Errorf("Failed to insert meta. err: %w", err)
+		if err := driver.InsertOval(&root); err != nil {
+			return xerrors.Errorf("Failed to insert OVAL. err: %w", err)
 		}
 		log15.Info("Finish", "Updated", len(root.Definitions))
 	}

--- a/commands/fetch-alpine.go
+++ b/commands/fetch-alpine.go
@@ -65,7 +65,6 @@ func fetchAlpine(cmd *cobra.Command, args []string) (err error) {
 	if fetchMeta.OutDated() {
 		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
@@ -84,7 +83,7 @@ func fetchAlpine(cmd *cobra.Command, args []string) (err error) {
 	for _, r := range results {
 		secdb, err := unmarshalYml(r.Body)
 		if err != nil {
-			return xerrors.Errorf("Failed to unmarshal yml. err %w", err)
+			return xerrors.Errorf("Failed to unmarshal yml. err: %w", err)
 		}
 
 		defs := models.ConvertAlpineToModel(secdb)

--- a/commands/fetch-amazon.go
+++ b/commands/fetch-amazon.go
@@ -93,21 +93,8 @@ func fetchAmazon(cmd *cobra.Command, args []string) (err error) {
 }
 
 func execute(driver db.DB, root *models.Root) error {
-	timestamp, err := time.Parse("2006-01-02T15:04:05Z", time.Now().Format("2006-01-02T15:04:05Z"))
-	if err != nil {
-		return fmt.Errorf("Failed to parse timestamp. err: %w", err)
-	}
-
-	fmeta := models.FileMeta{
-		Timestamp: timestamp,
-		FileName:  fmt.Sprintf("FetchUpdateInfoAmazonLinux%s", root.OSVersion),
-	}
-
-	if err := driver.InsertOval(root, fmeta); err != nil {
-		return fmt.Errorf("Failed to insert OVAL: %w", err)
-	}
-	if err := driver.InsertFileMeta(fmeta); err != nil {
-		return xerrors.Errorf("Failed to insert meta. err %w", err)
+	if err := driver.InsertOval(root); err != nil {
+		return xerrors.Errorf("Failed to insert OVAL. err: %w", err)
 	}
 	log15.Info("Finish", "Updated", len(root.Definitions))
 

--- a/commands/fetch-amazon.go
+++ b/commands/fetch-amazon.go
@@ -36,9 +36,9 @@ func fetchAmazon(cmd *cobra.Command, args []string) (err error) {
 	driver, locked, err := db.NewDB(viper.GetString("dbtype"), viper.GetString("dbpath"), viper.GetBool("debug-sql"))
 	if err != nil {
 		if locked {
-			return xerrors.Errorf("Failed to open DB. Close DB connection before fetching: %w", err)
+			return xerrors.Errorf("Failed to open DB. Close DB connection before fetching. err: %w", err)
 		}
-		return xerrors.Errorf("Failed to open DB: %w", err)
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 	defer func() {
 		err := driver.CloseDB()
@@ -54,7 +54,6 @@ func fetchAmazon(cmd *cobra.Command, args []string) (err error) {
 	if fetchMeta.OutDated() {
 		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}

--- a/commands/fetch-debian.go
+++ b/commands/fetch-debian.go
@@ -42,7 +42,7 @@ func fetchDebian(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to open DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 	defer func() {
 		_ = driver.CloseDB()
@@ -55,7 +55,6 @@ func fetchDebian(cmd *cobra.Command, args []string) (err error) {
 	if fetchMeta.OutDated() {
 		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
@@ -78,7 +77,7 @@ func fetchDebian(cmd *cobra.Command, args []string) (err error) {
 	for _, r := range results {
 		ovalroot := oval.Root{}
 		if err = xml.Unmarshal(r.Body, &ovalroot); err != nil {
-			return xerrors.Errorf("Failed to unmarshal. url: %s, err: %w", r.URL, err)
+			return xerrors.Errorf("Failed to unmarshal xml. url: %s, err: %w", r.URL, err)
 		}
 		log15.Info("Fetched", "URL", r.URL, "OVAL definitions", len(ovalroot.Definitions.Definitions))
 

--- a/commands/fetch-debian.go
+++ b/commands/fetch-debian.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"encoding/xml"
-	"strings"
 	"time"
 
 	"github.com/inconshreveable/log15"
@@ -83,33 +82,15 @@ func fetchDebian(cmd *cobra.Command, args []string) (err error) {
 		}
 		log15.Info("Fetched", "URL", r.URL, "OVAL definitions", len(ovalroot.Definitions.Definitions))
 
-		defs := models.ConvertDebianToModel(&ovalroot)
-
-		var timeformat = "2006-01-02T15:04:05"
-		var t time.Time
-		t, err = time.Parse(timeformat, strings.Split(ovalroot.Generator.Timestamp, ".")[0])
-		if err != nil {
-			return xerrors.Errorf("Failed to parse timestamp. url: %s, err: %w", r.URL, err)
-		}
-
 		root := models.Root{
 			Family:      c.Debian,
 			OSVersion:   r.Target,
-			Definitions: defs,
+			Definitions: models.ConvertDebianToModel(&ovalroot),
 			Timestamp:   time.Now(),
 		}
 
-		ss := strings.Split(r.URL, "/")
-		fmeta := models.FileMeta{
-			Timestamp: t,
-			FileName:  ss[len(ss)-1],
-		}
-
-		if err := driver.InsertOval(&root, fmeta); err != nil {
-			return xerrors.Errorf("Failed to insert ova. err: %w", err)
-		}
-		if err := driver.InsertFileMeta(fmeta); err != nil {
-			return xerrors.Errorf("Failed to insert meta. err: %w", err)
+		if err := driver.InsertOval(&root); err != nil {
+			return xerrors.Errorf("Failed to insert OVAL. err: %w", err)
 		}
 		log15.Info("Finish", "Updated", len(root.Definitions))
 	}

--- a/commands/fetch-oracle.go
+++ b/commands/fetch-oracle.go
@@ -38,7 +38,7 @@ func fetchOracle(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to open DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -48,7 +48,6 @@ func fetchOracle(cmd *cobra.Command, args []string) (err error) {
 	if fetchMeta.OutDated() {
 		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
@@ -62,7 +61,7 @@ func fetchOracle(cmd *cobra.Command, args []string) (err error) {
 	for _, r := range results {
 		ovalroot := oval.Root{}
 		if err = xml.Unmarshal(r.Body, &ovalroot); err != nil {
-			return xerrors.Errorf("Failed to unmarshal. url: %s, err: %w", r.URL, err)
+			return xerrors.Errorf("Failed to unmarshal xml. url: %s, err: %w", r.URL, err)
 		}
 		log15.Info("Fetched", "URL", r.URL, "OVAL definitions", len(ovalroot.Definitions.Definitions))
 

--- a/commands/fetch-oracle.go
+++ b/commands/fetch-oracle.go
@@ -38,7 +38,7 @@ func fetchOracle(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to open DB. Close DB connection before fetching. err: %w", err)
 		}
-		return xerrors.Errorf("Failed to open DB: %w", err)
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()

--- a/commands/fetch-redhat.go
+++ b/commands/fetch-redhat.go
@@ -43,7 +43,7 @@ func fetchRedHat(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to open DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -53,7 +53,6 @@ func fetchRedHat(cmd *cobra.Command, args []string) (err error) {
 	if fetchMeta.OutDated() {
 		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
@@ -80,7 +79,7 @@ func fetchRedHat(cmd *cobra.Command, args []string) (err error) {
 	for _, r := range results {
 		ovalroot := oval.Root{}
 		if err = xml.Unmarshal(r.Body, &ovalroot); err != nil {
-			return xerrors.Errorf("Failed to unmarshal. url: %s, err: %w", r.URL, err)
+			return xerrors.Errorf("Failed to unmarshal xml. url: %s, err: %w", r.URL, err)
 		}
 		log15.Info("Fetched", "URL", r.URL, "OVAL definitions", len(ovalroot.Definitions.Definitions))
 		root := models.Root{

--- a/commands/fetch-suse.go
+++ b/commands/fetch-suse.go
@@ -107,28 +107,14 @@ func fetchSUSE(cmd *cobra.Command, args []string) (err error) {
 		}
 		log15.Info("Fetched", "URL", r.URL, "OVAL definitions", len(ovalroot.Definitions.Definitions))
 
-		var timeformat = "2006-01-02T15:04:05"
-		t, err := time.Parse(timeformat, ovalroot.Generator.Timestamp)
-		if err != nil {
-			return xerrors.Errorf("Failed to parse time. err: %w", err)
-		}
 		ss := strings.Split(r.URL, "/")
-		fmeta := models.FileMeta{
-			Timestamp: t,
-			FileName:  ss[len(ss)-1],
-		}
-
-		roots := models.ConvertSUSEToModel(fmeta.FileName, &ovalroot)
+		roots := models.ConvertSUSEToModel(ss[len(ss)-1], &ovalroot)
 		for _, root := range roots {
 			root.Timestamp = time.Now()
-			if err := driver.InsertOval(&root, fmeta); err != nil {
-				return xerrors.Errorf("Failed to insert oval. err: %w", err)
+			if err := driver.InsertOval(&root); err != nil {
+				return xerrors.Errorf("Failed to insert OVAL. err: %w", err)
 			}
 			log15.Info("Finish", "Updated", len(root.Definitions))
-		}
-
-		if err := driver.InsertFileMeta(fmeta); err != nil {
-			return xerrors.Errorf("Failed to insert meta. err: %w", err)
 		}
 	}
 

--- a/commands/fetch-suse.go
+++ b/commands/fetch-suse.go
@@ -79,7 +79,7 @@ func fetchSUSE(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to open DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -89,7 +89,6 @@ func fetchSUSE(cmd *cobra.Command, args []string) (err error) {
 	if fetchMeta.OutDated() {
 		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
@@ -103,7 +102,7 @@ func fetchSUSE(cmd *cobra.Command, args []string) (err error) {
 	for _, r := range results {
 		ovalroot := oval.Root{}
 		if err = xml.Unmarshal(r.Body, &ovalroot); err != nil {
-			return xerrors.Errorf("Failed to unmarshal. url: %s, err: %w", r.URL, err)
+			return xerrors.Errorf("Failed to unmarshal xml. url: %s, err: %w", r.URL, err)
 		}
 		log15.Info("Fetched", "URL", r.URL, "OVAL definitions", len(ovalroot.Definitions.Definitions))
 

--- a/commands/fetch-ubuntu.go
+++ b/commands/fetch-ubuntu.go
@@ -42,7 +42,7 @@ func fetchUbuntu(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to open DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()
@@ -52,7 +52,6 @@ func fetchUbuntu(cmd *cobra.Command, args []string) (err error) {
 	if fetchMeta.OutDated() {
 		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
-
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
@@ -75,7 +74,7 @@ func fetchUbuntu(cmd *cobra.Command, args []string) (err error) {
 	for _, r := range results {
 		ovalroot := oval.Root{}
 		if err = xml.Unmarshal(r.Body, &ovalroot); err != nil {
-			return xerrors.Errorf("Failed to unmarshal. url: %s, err: %s", r.URL, err)
+			return xerrors.Errorf("Failed to unmarshal xml. url: %s, err: %w", r.URL, err)
 		}
 		log15.Info("Fetched", "URL", r.URL, "OVAL definitions", len(ovalroot.Definitions.Definitions))
 

--- a/commands/server.go
+++ b/commands/server.go
@@ -39,7 +39,7 @@ func executeServer(cmd *cobra.Command, args []string) (err error) {
 		if locked {
 			return xerrors.Errorf("Failed to initialize DB. Close DB connection before fetching. err: %w", err)
 		}
-		return err
+		return xerrors.Errorf("Failed to open DB. err: %w", err)
 	}
 
 	fetchMeta, err := driver.GetFetchMeta()

--- a/db/db.go
+++ b/db/db.go
@@ -62,7 +62,7 @@ func newDB(dbType string) (DB, error) {
 	case dialectRedis:
 		return &RedisDriver{name: dbType}, nil
 	}
-	return nil, fmt.Errorf("Invalid database dialect. err: %s", dbType)
+	return nil, fmt.Errorf("Invalid database dialect. dbType: %s", dbType)
 }
 
 func formatFamilyAndOSVer(family, osVer string) (string, string, error) {

--- a/db/db.go
+++ b/db/db.go
@@ -23,8 +23,7 @@ type DB interface {
 
 	GetByPackName(family string, osVer string, packName string, arch string) ([]models.Definition, error)
 	GetByCveID(family string, osVer string, cveID string, arch string) ([]models.Definition, error)
-	InsertOval(*models.Root, models.FileMeta) error
-	InsertFileMeta(models.FileMeta) error
+	InsertOval(*models.Root) error
 	CountDefs(string, string) (int, error)
 	GetLastModified(string, string) (time.Time, error)
 }

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -76,14 +76,13 @@ func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool) (locked bool, e
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("Failed to open DB. dbtype: %s, dbpath: %s, err: %s", dbType, dbPath, err)
 		if r.name == dialectSqlite3 {
 			switch err.(sqlite3.Error).Code {
 			case sqlite3.ErrLocked, sqlite3.ErrBusy:
-				return true, fmt.Errorf(msg)
+				return true, xerrors.Errorf("Failed to open DB. dbtype: %s, dbpath: %s, err: %w", dbType, dbPath, err)
 			}
 		}
-		return false, fmt.Errorf(msg)
+		return false, xerrors.Errorf("Failed to open DB. dbtype: %s, dbpath: %s, err: %w", dbType, dbPath, err)
 	}
 
 	if r.name == dialectSqlite3 {
@@ -106,7 +105,7 @@ func (r *RDBDriver) MigrateDB() error {
 		&models.Cpe{},
 		&models.Debian{},
 	); err != nil {
-		return fmt.Errorf("Failed to migrate. err: %s", err)
+		return xerrors.Errorf("Failed to migrate. err: %w", err)
 	}
 
 	return nil
@@ -132,7 +131,7 @@ func (r *RDBDriver) CloseDB() (err error) {
 func (r *RDBDriver) GetByPackName(family, osVer, packName, arch string) ([]models.Definition, error) {
 	family, osVer, err := formatFamilyAndOSVer(family, osVer)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to formatFamilyAndOSVer. err: %s", err)
+		return nil, xerrors.Errorf("Failed to formatFamilyAndOSVer. err: %w", err)
 	}
 
 	q := r.conn.
@@ -184,7 +183,7 @@ func (r *RDBDriver) GetByPackName(family, osVer, packName, arch string) ([]model
 func (r *RDBDriver) GetByCveID(family, osVer, cveID, arch string) ([]models.Definition, error) {
 	family, osVer, err := formatFamilyAndOSVer(family, osVer)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to formatFamilyAndOSVer. err: %s", err)
+		return nil, xerrors.Errorf("Failed to formatFamilyAndOSVer. err: %w", err)
 	}
 
 	q := r.conn.
@@ -307,7 +306,7 @@ func (r *RDBDriver) InsertOval(root *models.Root) error {
 func (r *RDBDriver) CountDefs(family, osVer string) (int, error) {
 	family, osVer, err := formatFamilyAndOSVer(family, osVer)
 	if err != nil {
-		return 0, fmt.Errorf("Failed to formatFamilyAndOSVer. err: %s", err)
+		return 0, xerrors.Errorf("Failed to formatFamilyAndOSVer. err: %w", err)
 	}
 
 	root := models.Root{}
@@ -330,7 +329,7 @@ func (r *RDBDriver) CountDefs(family, osVer string) (int, error) {
 func (r *RDBDriver) GetLastModified(family, osVer string) (time.Time, error) {
 	family, osVer, err := formatFamilyAndOSVer(family, osVer)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("Failed to formatFamilyAndOSVer. err: %s", err)
+		return time.Time{}, xerrors.Errorf("Failed to formatFamilyAndOSVer. err: %w", err)
 	}
 
 	root := models.Root{}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -283,7 +283,7 @@ func (r *RDBDriver) InsertOval(root *models.Root) error {
 	bar := pb.StartNew(len(root.Definitions))
 	if err := tx.Omit("Definitions").Create(&root).Error; err != nil {
 		tx.Rollback()
-		return xerrors.Errorf("Failed to insert. err: %w", err)
+		return xerrors.Errorf("Failed to insert Root. err: %w", err)
 	}
 
 	for i := range root.Definitions {
@@ -293,7 +293,7 @@ func (r *RDBDriver) InsertOval(root *models.Root) error {
 	for idx := range chunkSlice(len(root.Definitions), batchSize) {
 		if err := tx.Create(root.Definitions[idx.From:idx.To]).Error; err != nil {
 			tx.Rollback()
-			return xerrors.Errorf("Failed to insert. err: %w", err)
+			return xerrors.Errorf("Failed to insert Definitions. err: %w", err)
 		}
 		bar.Add(idx.To - idx.From)
 	}

--- a/db/redis.go
+++ b/db/redis.go
@@ -81,7 +81,7 @@ func (r *RedisDriver) Name() string {
 
 // OpenDB opens Database
 func (r *RedisDriver) OpenDB(dbType, dbPath string, debugSQL bool) (locked bool, err error) {
-	if err = r.connectRedis(dbPath); err != nil {
+	if err := r.connectRedis(dbPath); err != nil {
 		return false, xerrors.Errorf("Failed to open DB. dbtype: %s, dbpath: %s, err: %w", dbType, dbPath, err)
 	}
 	return false, nil
@@ -116,7 +116,7 @@ func (r *RedisDriver) MigrateDB() error {
 func (r *RedisDriver) GetByPackName(family, osVer, packName, arch string) ([]models.Definition, error) {
 	family, osVer, err := formatFamilyAndOSVer(family, osVer)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to formatFamilyAndOSVer. err: %s", err)
+		return nil, xerrors.Errorf("Failed to formatFamilyAndOSVer. err: %w", err)
 	}
 
 	ctx := context.Background()
@@ -130,7 +130,7 @@ func (r *RedisDriver) GetByPackName(family, osVer, packName, arch string) ([]mod
 		} else {
 			dbsize, err := r.conn.DBSize(ctx).Result()
 			if err != nil {
-				return nil, fmt.Errorf("Failed to DBSize. err: %s", err)
+				return nil, xerrors.Errorf("Failed to DBSize. err: %w", err)
 			}
 
 			var cursor uint64
@@ -139,7 +139,7 @@ func (r *RedisDriver) GetByPackName(family, osVer, packName, arch string) ([]mod
 				var err error
 				keys, cursor, err = r.conn.Scan(ctx, cursor, fmt.Sprintf("%s#%s", key, "*"), dbsize/5).Result()
 				if err != nil {
-					return nil, fmt.Errorf("Failed to Scan. err: %s", err)
+					return nil, xerrors.Errorf("Failed to Scan. err: %w", err)
 				}
 
 				pkgKeys = append(pkgKeys, keys...)
@@ -159,14 +159,14 @@ func (r *RedisDriver) GetByPackName(family, osVer, packName, arch string) ([]mod
 	}
 	cmders, err := pipe.Exec(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to exec pipeline. err: %s", err)
+		return nil, xerrors.Errorf("Failed to exec pipeline. err: %w", err)
 	}
 
 	defIDs := []string{}
 	for _, cmder := range cmders {
 		result, err := cmder.(*redis.StringSliceCmd).Result()
 		if err != nil {
-			return nil, fmt.Errorf("Failed to SMembers. err: %s", err)
+			return nil, xerrors.Errorf("Failed to SMembers. err: %w", err)
 		}
 
 		defIDs = append(defIDs, result...)
@@ -177,18 +177,18 @@ func (r *RedisDriver) GetByPackName(family, osVer, packName, arch string) ([]mod
 
 	defStrs, err := r.conn.HMGet(ctx, fmt.Sprintf(defKeyFormat, family, osVer), defIDs...).Result()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to HMGet. err: %s", err)
+		return nil, xerrors.Errorf("Failed to HMGet. err: %w", err)
 	}
 
 	defs := []models.Definition{}
 	for _, defstr := range defStrs {
 		if defstr == nil {
-			return nil, fmt.Errorf("Failed to HMGet. err: Some fields do not exist. defIDs: %q", defIDs)
+			return nil, xerrors.Errorf("Failed to HMGet. err: Some fields do not exist. defIDs: %q", defIDs)
 		}
 
 		def, err := restoreDefinition(defstr.(string), family, osVer, arch)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to restoreDefinition. err: %s", err)
+			return nil, xerrors.Errorf("Failed to restoreDefinition. err: %w", err)
 		}
 		defs = append(defs, def)
 	}
@@ -200,13 +200,13 @@ func (r *RedisDriver) GetByPackName(family, osVer, packName, arch string) ([]mod
 func (r *RedisDriver) GetByCveID(family, osVer, cveID, arch string) ([]models.Definition, error) {
 	family, osVer, err := formatFamilyAndOSVer(family, osVer)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to formatFamilyAndOSVer. err: %s", err)
+		return nil, xerrors.Errorf("Failed to formatFamilyAndOSVer. err: %w", err)
 	}
 
 	ctx := context.Background()
 	defIDs, err := r.conn.SMembers(ctx, fmt.Sprintf(cveKeyFormat, family, osVer, cveID)).Result()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to SMembers. err: %s", err)
+		return nil, xerrors.Errorf("Failed to SMembers. err: %w", err)
 	}
 	if len(defIDs) == 0 {
 		return []models.Definition{}, nil
@@ -214,18 +214,18 @@ func (r *RedisDriver) GetByCveID(family, osVer, cveID, arch string) ([]models.De
 
 	defStrs, err := r.conn.HMGet(ctx, fmt.Sprintf(defKeyFormat, family, osVer), defIDs...).Result()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to HMGet. err: %s", err)
+		return nil, xerrors.Errorf("Failed to HMGet. err: %w", err)
 	}
 
 	defs := []models.Definition{}
 	for _, defstr := range defStrs {
 		if defstr == nil {
-			return nil, fmt.Errorf("Failed to HMGet. err: Some fields do not exist. defIDs: %q", defIDs)
+			return nil, xerrors.Errorf("Failed to HMGet. err: Some fields do not exist. defIDs: %q", defIDs)
 		}
 
 		def, err := restoreDefinition(defstr.(string), family, osVer, arch)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to restoreDefinition. err: %s", err)
+			return nil, xerrors.Errorf("Failed to restoreDefinition. err: %w", err)
 		}
 		defs = append(defs, def)
 	}
@@ -236,7 +236,7 @@ func (r *RedisDriver) GetByCveID(family, osVer, cveID, arch string) ([]models.De
 func restoreDefinition(defstr, family, version, arch string) (models.Definition, error) {
 	var def models.Definition
 	if err := json.Unmarshal([]byte(defstr), &def); err != nil {
-		return def, xerrors.Errorf("Failed to Unmarshal json. err: %w", err)
+		return models.Definition{}, xerrors.Errorf("Failed to Unmarshal JSON. err: %w", err)
 	}
 
 	switch family {
@@ -274,7 +274,7 @@ func (r *RedisDriver) InsertOval(root *models.Root) (err error) {
 
 	family, osVer, err := formatFamilyAndOSVer(root.Family, root.OSVersion)
 	if err != nil {
-		return fmt.Errorf("Failed to formatFamilyAndOSVer. err: %s", err)
+		return xerrors.Errorf("Failed to formatFamilyAndOSVer. err: %w", err)
 	}
 	log15.Info("Refreshing...", "Family", family, "Version", osVer)
 
@@ -284,13 +284,13 @@ func (r *RedisDriver) InsertOval(root *models.Root) (err error) {
 	oldDepsStr, err := r.conn.Get(ctx, depKey).Result()
 	if err != nil {
 		if !errors.Is(err, redis.Nil) {
-			return fmt.Errorf("Failed to Get key: %s. err: %s", depKey, err)
+			return xerrors.Errorf("Failed to Get key: %s. err: %w", depKey, err)
 		}
 		oldDepsStr = "{}"
 	}
 	var oldDeps map[string]map[string]map[string]struct{}
 	if err := json.Unmarshal([]byte(oldDepsStr), &oldDeps); err != nil {
-		return fmt.Errorf("Failed to unmarshal JSON. err: %s", err)
+		return xerrors.Errorf("Failed to unmarshal JSON. err: %w", err)
 	}
 
 	bar := pb.StartNew(len(root.Definitions))
@@ -299,11 +299,11 @@ func (r *RedisDriver) InsertOval(root *models.Root) (err error) {
 		for _, def := range root.Definitions[idx.From:idx.To] {
 			var dj []byte
 			if dj, err = json.Marshal(def); err != nil {
-				return fmt.Errorf("Failed to marshal json. err: %s", err)
+				return xerrors.Errorf("Failed to marshal json. err: %w", err)
 			}
 
 			if err := pipe.HSet(ctx, fmt.Sprintf(defKeyFormat, family, osVer), def.DefinitionID, string(dj)).Err(); err != nil {
-				return fmt.Errorf("Failed to HSet. err: %s", err)
+				return xerrors.Errorf("Failed to HSet. err: %w", err)
 			}
 			if _, ok := newDeps[def.DefinitionID]; !ok {
 				newDeps[def.DefinitionID] = map[string]map[string]struct{}{"cves": {}, "packages": {}}
@@ -311,7 +311,7 @@ func (r *RedisDriver) InsertOval(root *models.Root) (err error) {
 
 			for _, cve := range def.Advisory.Cves {
 				if err := pipe.SAdd(ctx, fmt.Sprintf(cveKeyFormat, family, osVer, cve.CveID), def.DefinitionID).Err(); err != nil {
-					return fmt.Errorf("Failed to SAdd CVE-Ir. err: %s", err)
+					return xerrors.Errorf("Failed to SAdd CVEID. err: %w", err)
 				}
 				newDeps[def.DefinitionID]["cves"][cve.CveID] = struct{}{}
 				if _, ok := oldDeps[def.DefinitionID]; ok {
@@ -330,7 +330,7 @@ func (r *RedisDriver) InsertOval(root *models.Root) (err error) {
 				}
 
 				if err := pipe.SAdd(ctx, fmt.Sprintf(pkgKeyFormat, family, osVer, pkgName), def.DefinitionID).Err(); err != nil {
-					return fmt.Errorf("Failed to SAdd Package. err: %s", err)
+					return xerrors.Errorf("Failed to SAdd Package. err: %w", err)
 				}
 				newDeps[def.DefinitionID]["packages"][pkgName] = struct{}{}
 				if _, ok := oldDeps[def.DefinitionID]; ok {
@@ -357,7 +357,7 @@ func (r *RedisDriver) InsertOval(root *models.Root) (err error) {
 			}
 		}
 		if _, err = pipe.Exec(ctx); err != nil {
-			return fmt.Errorf("Failed to exec pipeline. err: %s", err)
+			return xerrors.Errorf("Failed to exec pipeline. err: %w", err)
 		}
 		bar.Add(idx.To - idx.From)
 	}
@@ -367,30 +367,30 @@ func (r *RedisDriver) InsertOval(root *models.Root) (err error) {
 	for defID, definitions := range oldDeps {
 		for cveID := range definitions["cves"] {
 			if err := pipe.SRem(ctx, fmt.Sprintf(cveKeyFormat, family, osVer, cveID), defID).Err(); err != nil {
-				return fmt.Errorf("Failed to SRem. err: %s", err)
+				return xerrors.Errorf("Failed to SRem. err: %w", err)
 			}
 		}
 		for pack := range definitions["packages"] {
 			if err := pipe.SRem(ctx, fmt.Sprintf(cveKeyFormat, family, osVer, pack), defID).Err(); err != nil {
-				return fmt.Errorf("Failed to SRem. err: %s", err)
+				return xerrors.Errorf("Failed to SRem. err: %w", err)
 			}
 		}
 		if err := pipe.HDel(ctx, fmt.Sprintf(defKeyFormat, family, osVer), defID).Err(); err != nil {
-			return fmt.Errorf("Failed to HDel. err: %s", err)
+			return xerrors.Errorf("Failed to HDel. err: %w", err)
 		}
 	}
 	newDepsJSON, err := json.Marshal(newDeps)
 	if err != nil {
-		return fmt.Errorf("Failed to Marshal JSON. err: %s", err)
+		return xerrors.Errorf("Failed to Marshal JSON. err: %w", err)
 	}
 	if err := pipe.Set(ctx, depKey, string(newDepsJSON), 0).Err(); err != nil {
-		return fmt.Errorf("Failed to Set depkey. err: %s", err)
+		return xerrors.Errorf("Failed to Set depkey. err: %w", err)
 	}
 	if err := pipe.Set(ctx, fmt.Sprintf(lastModifiedKeyFormat, family, osVer), root.Timestamp.Format("2006-01-02T15:04:05Z"), 0).Err(); err != nil {
-		return fmt.Errorf("Failed to Set LastModifiedKey. err: %s", err)
+		return xerrors.Errorf("Failed to Set LastModifiedKey. err: %w", err)
 	}
 	if _, err = pipe.Exec(ctx); err != nil {
-		return fmt.Errorf("Failed to exec pipeline. err: %s", err)
+		return xerrors.Errorf("Failed to exec pipeline. err: %w", err)
 	}
 
 	return nil
@@ -400,13 +400,13 @@ func (r *RedisDriver) InsertOval(root *models.Root) (err error) {
 func (r *RedisDriver) CountDefs(family, osVer string) (int, error) {
 	family, osVer, err := formatFamilyAndOSVer(family, osVer)
 	if err != nil {
-		return 0, fmt.Errorf("Failed to formatFamilyAndOSVer. err: %s", err)
+		return 0, xerrors.Errorf("Failed to formatFamilyAndOSVer. err: %w", err)
 	}
 
 	count, err := r.conn.HLen(context.Background(), fmt.Sprintf(defKeyFormat, family, osVer)).Result()
 	if err != nil {
 		if !errors.Is(err, redis.Nil) {
-			return 0, fmt.Errorf("Failed to HLen. err: %s", err)
+			return 0, xerrors.Errorf("Failed to HLen. err: %w", err)
 		}
 		return 0, nil
 	}
@@ -418,20 +418,20 @@ func (r *RedisDriver) CountDefs(family, osVer string) (int, error) {
 func (r *RedisDriver) GetLastModified(family, osVer string) (time.Time, error) {
 	family, osVer, err := formatFamilyAndOSVer(family, osVer)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("Failed to formatFamilyAndOSVer. err: %s", err)
+		return time.Time{}, xerrors.Errorf("Failed to formatFamilyAndOSVer. err: %w", err)
 	}
 
 	lastModifiedStr, err := r.conn.Get(context.Background(), fmt.Sprintf(lastModifiedKeyFormat, family, osVer)).Result()
 	if err != nil {
 		if !errors.Is(err, redis.Nil) {
-			return time.Time{}, fmt.Errorf("Failed to Get. err: %s", err)
+			return time.Time{}, xerrors.Errorf("Failed to Get. err: %w", err)
 		}
 		return time.Now().AddDate(-100, 0, 0), nil
 	}
 
 	lastModified, err := time.Parse("2006-01-02T15:04:05Z", lastModifiedStr)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("Failed to parse LastModifier. err: %s", err)
+		return time.Time{}, xerrors.Errorf("Failed to parse LastModifier. err: %w", err)
 	}
 	return lastModified, nil
 }
@@ -442,12 +442,12 @@ func (r *RedisDriver) IsGovalDictModelV1() (bool, error) {
 
 	exists, err := r.conn.Exists(ctx, fetchMetaKey).Result()
 	if err != nil {
-		return false, fmt.Errorf("Failed to Exists. err: %s", err)
+		return false, xerrors.Errorf("Failed to Exists. err: %w", err)
 	}
 	if exists == 0 {
 		keys, _, err := r.conn.Scan(ctx, 0, "OVAL#*", 1).Result()
 		if err != nil {
-			return false, fmt.Errorf("Failed to Scan. err: %s", err)
+			return false, xerrors.Errorf("Failed to Scan. err: %w", err)
 		}
 		if len(keys) == 0 {
 			return false, nil
@@ -464,7 +464,7 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 
 	exists, err := r.conn.Exists(ctx, fetchMetaKey).Result()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to Exists. err: %s", err)
+		return nil, xerrors.Errorf("Failed to Exists. err: %w", err)
 	}
 	if exists == 0 {
 		return &models.FetchMeta{GovalDictRevision: c.Revision, SchemaVersion: models.LatestSchemaVersion}, nil
@@ -472,16 +472,16 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 
 	revision, err := r.conn.HGet(ctx, fetchMetaKey, "Revision").Result()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to HGet Revision. err: %s", err)
+		return nil, xerrors.Errorf("Failed to HGet Revision. err: %w", err)
 	}
 
 	verstr, err := r.conn.HGet(ctx, fetchMetaKey, "SchemaVersion").Result()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to HGet SchemaVersion. err: %s", err)
+		return nil, xerrors.Errorf("Failed to HGet SchemaVersion. err: %w", err)
 	}
 	version, err := strconv.ParseUint(verstr, 10, 8)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to ParseUint. err: %s", err)
+		return nil, xerrors.Errorf("Failed to ParseUint. err: %w", err)
 	}
 
 	return &models.FetchMeta{GovalDictRevision: revision, SchemaVersion: uint(version)}, nil

--- a/fetcher/alpine.go
+++ b/fetcher/alpine.go
@@ -2,6 +2,8 @@ package fetcher
 
 import (
 	"fmt"
+
+	"golang.org/x/xerrors"
 )
 
 const community = "https://secdb.alpinelinux.org/v%s/community.yaml"
@@ -35,7 +37,7 @@ func FetchAlpineFiles(versions []string) ([]FetchResult, error) {
 	results, err := fetchFeedFiles(reqs)
 	if err != nil {
 		return nil,
-			fmt.Errorf("Failed to fetch. err: %s", err)
+			xerrors.Errorf("Failed to fetch. err: %w", err)
 	}
 	return results, nil
 }

--- a/fetcher/amazon.go
+++ b/fetcher/amazon.go
@@ -10,6 +10,7 @@ import (
 	"path"
 
 	"github.com/inconshreveable/log15"
+	"golang.org/x/xerrors"
 )
 
 const (
@@ -85,7 +86,7 @@ func FetchUpdateInfoAmazonLinux2() (*UpdateInfo, error) {
 func fetchUpdateInfoAmazonLinux(mirrorListURL string) (uinfo *UpdateInfo, err error) {
 	results, err := fetchFeedFiles([]fetchRequest{{url: mirrorListURL}})
 	if err != nil || len(results) != 1 {
-		return nil, fmt.Errorf("Failed to fetch mirror list files. err: %s", err)
+		return nil, xerrors.Errorf("Failed to fetch mirror list files. err: %w", err)
 	}
 
 	mirrors := []string{}
@@ -98,7 +99,7 @@ func fetchUpdateInfoAmazonLinux(mirrorListURL string) (uinfo *UpdateInfo, err er
 
 	uinfoURLs, err := fetchUpdateInfoURL(mirrors)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch updateInfo URL. err: %s", err)
+		return nil, xerrors.Errorf("Failed to fetch updateInfo URL. err: %w", err)
 	}
 	for _, url := range uinfoURLs {
 		uinfo, err = fetchUpdateInfo(url)
@@ -164,11 +165,11 @@ func fetchUpdateInfoURL(mirrors []string) (updateInfoURLs []string, err error) {
 func fetchUpdateInfo(url string) (*UpdateInfo, error) {
 	results, err := fetchFeedFiles([]fetchRequest{{url: url}})
 	if err != nil || len(results) != 1 {
-		return nil, fmt.Errorf("Failed to fetch updateInfo. err: %s", err)
+		return nil, xerrors.Errorf("Failed to fetch updateInfo. err: %w", err)
 	}
 	r, err := gzip.NewReader(bytes.NewBuffer(results[0].Body))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to decompress updateInfo. err: %s", err)
+		return nil, xerrors.Errorf("Failed to decompress updateInfo. err: %w", err)
 	}
 	defer r.Close()
 

--- a/fetcher/debian.go
+++ b/fetcher/debian.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/vulsio/goval-dictionary/config"
+	"golang.org/x/xerrors"
 )
 
 // https://www.debian.org/security/oval/
@@ -52,7 +53,7 @@ func FetchDebianFiles(versions []string) ([]FetchResult, error) {
 	results, err := fetchFeedFiles(reqs)
 	if err != nil {
 		return nil,
-			fmt.Errorf("Failed to fetch. err: %s", err)
+			xerrors.Errorf("Failed to fetch. err: %w", err)
 	}
 	return results, nil
 }

--- a/fetcher/oracle.go
+++ b/fetcher/oracle.go
@@ -2,6 +2,8 @@ package fetcher
 
 import (
 	"fmt"
+
+	"golang.org/x/xerrors"
 )
 
 func newOracleFetchRequests() (reqs []fetchRequest) {
@@ -23,7 +25,7 @@ func FetchOracleFiles() ([]FetchResult, error) {
 	results, err := fetchFeedFiles(reqs)
 	if err != nil {
 		return nil,
-			fmt.Errorf("Failed to fetch. err: %s", err)
+			xerrors.Errorf("Failed to fetch. err: %w", err)
 	}
 	return results, nil
 }

--- a/fetcher/redhat.go
+++ b/fetcher/redhat.go
@@ -2,6 +2,8 @@ package fetcher
 
 import (
 	"fmt"
+
+	"golang.org/x/xerrors"
 )
 
 func newRedHatFetchRequests(target []string) (reqs []fetchRequest) {
@@ -27,7 +29,7 @@ func FetchRedHatFiles(versions []string) ([]FetchResult, error) {
 	results, err := fetchFeedFiles(reqs)
 	if err != nil {
 		return nil,
-			fmt.Errorf("Failed to fetch. err: %s", err)
+			xerrors.Errorf("Failed to fetch. err: %w", err)
 	}
 	return results, nil
 }

--- a/fetcher/suse.go
+++ b/fetcher/suse.go
@@ -2,6 +2,8 @@ package fetcher
 
 import (
 	"fmt"
+
+	"golang.org/x/xerrors"
 )
 
 // https://ftp.suse.com/pub/projects/security/oval/opensuse.leap.42.2.xml
@@ -31,7 +33,7 @@ func FetchSUSEFiles(suseType string, versions []string) ([]FetchResult, error) {
 	results, err := fetchFeedFiles(reqs)
 	if err != nil {
 		return nil,
-			fmt.Errorf("Failed to fetch. err: %s", err)
+			xerrors.Errorf("Failed to fetch. err: %w", err)
 	}
 	return results, nil
 }

--- a/fetcher/ubuntu.go
+++ b/fetcher/ubuntu.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/vulsio/goval-dictionary/config"
+	"golang.org/x/xerrors"
 )
 
 func newUbuntuFetchRequests(target []string) (reqs []fetchRequest) {
@@ -62,7 +63,7 @@ func FetchUbuntuFiles(versions []string) ([]FetchResult, error) {
 	results, err := fetchFeedFiles(reqs)
 	if err != nil {
 		return nil,
-			fmt.Errorf("Failed to fetch. err: %s", err)
+			xerrors.Errorf("Failed to fetch. err: %w", err)
 	}
 	return results, nil
 }

--- a/models/models.go
+++ b/models/models.go
@@ -21,14 +21,6 @@ func (f FetchMeta) OutDated() bool {
 	return f.SchemaVersion != LatestSchemaVersion
 }
 
-// FileMeta has metadata
-type FileMeta struct {
-	ID uint `gorm:"primary_key"`
-
-	FileName  string `gorm:"type:varchar(255)"`
-	Timestamp time.Time
-}
-
 // Root is root struct
 type Root struct {
 	ID          uint   `gorm:"primary_key"`

--- a/server/server.go
+++ b/server/server.go
@@ -30,7 +30,7 @@ func Start(logToFile bool, logDir string, driver db.DB) error {
 		logPath := filepath.Join(logDir, "access.log")
 		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 		if err != nil {
-			return xerrors.Errorf("Failed to open a log file: %s", err)
+			return xerrors.Errorf("Failed to open a log file. err: %w", err)
 		}
 		defer f.Close()
 		e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{Output: f}))


### PR DESCRIPTION
# What did you implement:
goval-dictionary does not have a force option, so we could not force the OVAL to be updated. I thought about adding a force option or removing the skip scheme, but decided to remove the skip.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

