### PR TITLE
fix(redis): Failed to detect CVE with OVAL: Failed to get ubuntu OVAL info by package

### DIFF
--- a/db/redis.go
+++ b/db/redis.go
@@ -181,9 +181,12 @@ func (r *RedisDriver) GetByPackName(family, osVer, packName, arch string) ([]mod
 	}
 
 	defs := []models.Definition{}
-	for _, defstr := range defStrs {
+	for i, defstr := range defStrs {
 		if defstr == nil {
-			return nil, xerrors.Errorf("Failed to HMGet. err: Some fields do not exist. defIDs: %q", defIDs)
+			// Only Logging
+			// TODO: remove invalid keys
+			log15.Error("Failed to HMGet. Some fields do not exist. continue scanning", "Family", family, "Version", osVer, "defID", defIDs[i])
+			continue
 		}
 
 		def, err := restoreDefinition(defstr.(string), family, osVer, arch)
@@ -218,9 +221,11 @@ func (r *RedisDriver) GetByCveID(family, osVer, cveID, arch string) ([]models.De
 	}
 
 	defs := []models.Definition{}
-	for _, defstr := range defStrs {
+	for i, defstr := range defStrs {
 		if defstr == nil {
-			return nil, xerrors.Errorf("Failed to HMGet. err: Some fields do not exist. defIDs: %q", defIDs)
+			// Only Logging
+			// TODO: remove invalid keys
+			log15.Error("Failed to HMGet. Some fields do not exist. continue scanning", "Family", family, "Version", osVer, "defID", defIDs[i])
 		}
 
 		def, err := restoreDefinition(defstr.(string), family, osVer, arch)


### PR DESCRIPTION
# What did you implement:

>Failed to detect CVE with OVAL: Failed to get ubuntu OVAL info by package: oval.request{packName:&#34;linux-aws&#34;, versionRelease:&#34;5.4.0-1037.39~18.04.1&#34;, newVersionRelease:&#34;&#34;, arch:&#34;&#34;, binaryPackNames:[]string(nil), isSrcPack:false, modularityLabel:&#34;&#34;}, err: Failed to HMGet. err: Some fields do not exist. defIDs: [&#34;oval:com.ubuntu.bionic:def:201922140000000&#34; &#34;oval:com.ubuntu.bionic:def:201513500000000&#34; &#34;oval:com.ubuntu.bionic:def:2019148350000000&#34; 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
