### PR TITLE
fix(fetch/debian): fix unmarshal xml

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.32
+          version: v1.42
           args: --timeout=10m
           
           # Optional: working directory, useful for monorepos

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,7 +19,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.14.x
+        go-version: 1.17.x
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -19,4 +19,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_user_name: kotakanbe
           git_user_email: kotakanbe@gmail.com
-          go_version: 1.14.x
+          go_version: 1.17.x

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
   goarch:
   - amd64
   main: .
-  ldflags: -s -w -X main.version={{.Version}} -X main.revision={{.Commit}}
+  ldflags: -s -w -X github.com/vulsio/goval-dictionary/config.Version={{.Version}} -X github.com/vulsio/goval-dictionary/config.Revision={{.Commit}}
   binary: goval-dictionary
 archives:
 - name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'

--- a/commands/fetch-debian.go
+++ b/commands/fetch-debian.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"encoding/xml"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/vulsio/goval-dictionary/models"
 	"github.com/vulsio/goval-dictionary/util"
 	"github.com/ymomoi/goval-parser/oval"
+	"golang.org/x/net/html/charset"
 	"golang.org/x/xerrors"
 )
 
@@ -76,7 +78,10 @@ func fetchDebian(cmd *cobra.Command, args []string) (err error) {
 
 	for _, r := range results {
 		ovalroot := oval.Root{}
-		if err = xml.Unmarshal(r.Body, &ovalroot); err != nil {
+
+		decoder := xml.NewDecoder(bytes.NewReader(r.Body))
+		decoder.CharsetReader = charset.NewReaderLabel
+		if err := decoder.Decode(&ovalroot); err != nil {
 			return xerrors.Errorf("Failed to unmarshal xml. url: %s, err: %w", r.URL, err)
 		}
 		log15.Info("Fetched", "URL", r.URL, "OVAL definitions", len(ovalroot.Definitions.Definitions))

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/viper v1.8.1
 	github.com/ymomoi/goval-parser v0.0.0-20170813122243-0a0be1dd9d08
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
+	golang.org/x/net v0.0.0-20211206223403-eba003a116a9
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/yaml.v2 v2.4.0
@@ -61,7 +62,6 @@ require (
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.1 // indirect
-	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
 	golang.org/x/text v0.3.6 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -659,8 +659,9 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 h1:DzZ89McO9/gWPsQXS/FVKAlG02ZjaQ6AlZRBimEYOd0=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
+golang.org/x/net v0.0.0-20211206223403-eba003a116a9 h1:HhGRSJWlxVO54+s9MeOVrZrbnwv+6oZQIvsUrMUte7U=
+golang.org/x/net v0.0.0-20211206223403-eba003a116a9/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/models/suse.go
+++ b/models/suse.go
@@ -308,7 +308,7 @@ func getOSNameVersion(s string) (string, string, error) {
 	ss := strings.Split(strings.ToLower(s), " ")
 	osVerIndex := 0
 	for i := len(ss) - 1; i >= 0; i = i - 1 {
-		_, err := strconv.ParseFloat(ss[i], 0)
+		_, err := strconv.ParseFloat(ss[i], 32)
 		if err != nil {
 			if strings.Contains(ss[i], "-") {
 				sss := strings.Split(ss[i], "-")


### PR DESCRIPTION
# What did you implement:
Debian's OVAL XML files have suddenly changed to ASCII encoding.
xml.Unmarshal does not support anything other than UTF-8, so this has been fixed.

Duplicate PR: https://github.com/vulsio/goval-dictionary/pull/171

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## upstream/master
```console
$ goval-dictictionary fetch debian 9
INFO[12-07|15:50:35] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-stretch.xml
INFO[12-07|15:50:38] Fetched...                               URL=https://www.debian.org/security/oval/oval-definitions-stretch.xml
INFO[12-07|15:50:38] Finished fetching OVAL definitions 
Failed to unmarshal xml. url: https://www.debian.org/security/oval/oval-definitions-stretch.xml, err: xml: encoding "ASCII" declared but Decoder.CharsetReader is nil

$ goval-dictictionary fetch debian 10
INFO[12-07|15:50:13] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-buster.xml
INFO[12-07|15:50:15] Fetched...                               URL=https://www.debian.org/security/oval/oval-definitions-buster.xml
INFO[12-07|15:50:15] Finished fetching OVAL definitions 
Failed to unmarshal xml. url: https://www.debian.org/security/oval/oval-definitions-buster.xml, err: xml: encoding "ASCII" declared but Decoder.CharsetReader is nil

$ goval-dictictionary fetch debian 11
INFO[12-07|15:50:05] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-bullseye.xml
INFO[12-07|15:50:07] Fetched...                               URL=https://www.debian.org/security/oval/oval-definitions-bullseye.xml
INFO[12-07|15:50:07] Finished fetching OVAL definitions 
Failed to unmarshal xml. url: https://www.debian.org/security/oval/oval-definitions-bullseye.xml, err: xml: encoding "ASCII" declared but Decoder.CharsetReader is nil
```

## MaineK00n/fix-debian-fetch
```console
$ goval-dictictionary fetch debian 9
INFO[12-07|15:51:03] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-stretch.xml
INFO[12-07|15:51:05] Fetched...                               URL=https://www.debian.org/security/oval/oval-definitions-stretch.xml
INFO[12-07|15:51:05] Finished fetching OVAL definitions 
INFO[12-07|15:51:07] Fetched                                  URL=https://www.debian.org/security/oval/oval-definitions-stretch.xml OVAL definitions=25006
INFO[12-07|15:51:07] Refreshing...                            Family=debian Version=9
INFO[12-07|15:51:07] Inserting new Definitions... 
25006 / 25006 [---------------------------------------------------------------------------------------------------------------------------------] 100.00% 36018 p/s
INFO[12-07|15:51:08] Finish                                   Updated=25006

$ goval-dictictionary fetch debian 10
INFO[12-07|15:51:19] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-buster.xml
INFO[12-07|15:51:21] Fetched...                               URL=https://www.debian.org/security/oval/oval-definitions-buster.xml
INFO[12-07|15:51:21] Finished fetching OVAL definitions 
INFO[12-07|15:51:23] Fetched                                  URL=https://www.debian.org/security/oval/oval-definitions-buster.xml OVAL definitions=22502
INFO[12-07|15:51:23] Refreshing...                            Family=debian Version=10
INFO[12-07|15:51:23] Inserting new Definitions... 
22501 / 22501 [---------------------------------------------------------------------------------------------------------------------------------] 100.00% 36053 p/s
INFO[12-07|15:51:23] Finish                                   Updated=22501

$ goval-dictictionary fetch debian 11
INFO[12-07|15:51:39] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-bullseye.xml
INFO[12-07|15:51:41] Fetched...                               URL=https://www.debian.org/security/oval/oval-definitions-bullseye.xml
INFO[12-07|15:51:41] Finished fetching OVAL definitions 
INFO[12-07|15:51:42] Fetched                                  URL=https://www.debian.org/security/oval/oval-definitions-bullseye.xml OVAL definitions=22290
INFO[12-07|15:51:42] Refreshing...                            Family=debian Version=11
INFO[12-07|15:51:42] Inserting new Definitions... 
22288 / 22288 [---------------------------------------------------------------------------------------------------------------------------------] 100.00% 35065 p/s
INFO[12-07|15:51:43] Finish                                   Updated=22288
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

