### PR TITLE
feat(redis): delete missing defID field in Sets

### DIFF
--- a/db/redis.go
+++ b/db/redis.go
@@ -188,6 +188,7 @@ func (r *RedisDriver) GetByPackName(family, osVer, packName, arch string) ([]mod
 	delDefIDs := []string{}
 	for i, defstr := range defStrs {
 		if defstr == nil {
+			// TODO: Check the occurrence of this log while operating the service. Originally, I want to return an error because the DB is broken.
 			// Only Logging and stack missing defID fields to be deleted
 			log15.Error("Failed to HMGet. err: Some fields do not exist. continue scanning", "Family", family, "Version", osVer, "defID", defIDs[i])
 			delDefIDs = append(delDefIDs, defIDs[i])
@@ -238,6 +239,7 @@ func (r *RedisDriver) GetByCveID(family, osVer, cveID, arch string) ([]models.De
 	delDefIDs := []string{}
 	for i, defstr := range defStrs {
 		if defstr == nil {
+			// TODO: Check the occurrence of this log while operating the service. Originally, I want to return an error because the DB is broken.
 			// Only Logging and stack missing defID fields to be deleted
 			log15.Error("Failed to HMGet. err: Some fields do not exist. continue scanning", "Family", family, "Version", osVer, "defID", defIDs[i])
 			delDefIDs = append(delDefIDs, defIDs[i])

--- a/db/redis.go
+++ b/db/redis.go
@@ -185,11 +185,12 @@ func (r *RedisDriver) GetByPackName(family, osVer, packName, arch string) ([]mod
 	}
 
 	defs := []models.Definition{}
+	delDefIDs := []string{}
 	for i, defstr := range defStrs {
 		if defstr == nil {
-			// Only Logging
-			// TODO: remove invalid keys
-			log15.Warn("Failed to HMGet. Some fields do not exist. continue scanning", "Family", family, "Version", osVer, "defID", defIDs[i])
+			// Only Logging and stack missing defID fields to be deleted
+			log15.Error("Failed to HMGet. err: Some fields do not exist. continue scanning", "Family", family, "Version", osVer, "defID", defIDs[i])
+			delDefIDs = append(delDefIDs, defIDs[i])
 			continue
 		}
 
@@ -198,6 +199,15 @@ func (r *RedisDriver) GetByPackName(family, osVer, packName, arch string) ([]mod
 			return nil, xerrors.Errorf("Failed to restoreDefinition. err: %w", err)
 		}
 		defs = append(defs, def)
+	}
+	if len(delDefIDs) > 0 {
+		pipe := r.conn.Pipeline()
+		for _, pkgKey := range pkgKeys {
+			_ = pipe.SRem(ctx, pkgKey, delDefIDs)
+		}
+		if _, err := pipe.Exec(ctx); err != nil {
+			return nil, xerrors.Errorf("Failed to exec pipeline. err: %w", err)
+		}
 	}
 
 	return defs, nil
@@ -225,11 +235,12 @@ func (r *RedisDriver) GetByCveID(family, osVer, cveID, arch string) ([]models.De
 	}
 
 	defs := []models.Definition{}
+	delDefIDs := []string{}
 	for i, defstr := range defStrs {
 		if defstr == nil {
-			// Only Logging
-			// TODO: remove invalid keys
-			log15.Warn("Failed to HMGet. Some fields do not exist. continue scanning", "Family", family, "Version", osVer, "defID", defIDs[i])
+			// Only Logging and stack missing defID fields to be deleted
+			log15.Error("Failed to HMGet. err: Some fields do not exist. continue scanning", "Family", family, "Version", osVer, "defID", defIDs[i])
+			delDefIDs = append(delDefIDs, defIDs[i])
 			continue
 		}
 
@@ -238,6 +249,11 @@ func (r *RedisDriver) GetByCveID(family, osVer, cveID, arch string) ([]models.De
 			return nil, xerrors.Errorf("Failed to restoreDefinition. err: %w", err)
 		}
 		defs = append(defs, def)
+	}
+	if len(delDefIDs) > 0 {
+		if _, err := r.conn.SRem(ctx, fmt.Sprintf(cveKeyFormat, family, osVer, cveID), delDefIDs).Result(); err != nil {
+			return nil, xerrors.Errorf("Failed to exec pipeline. err: %w", err)
+		}
 	}
 
 	return defs, nil


### PR DESCRIPTION
# What did you implement:

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes #173 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## package search
```console
// setup
$ redis-cli -p 6379
127.0.0.1:6379> SMEMBERS OVAL#debian#11#PKG#a2ps
1) "oval:org.debian:def:75476148081331502013618590951901882535"
2) "oval:org.debian:def:test" // missing defID
3) "oval:org.debian:def:88988697754130173838013832986587830139"
4) "oval:org.debian:def:89135559689250371593682731796707320194"
5) "oval:org.debian:def:287503723613106787615900001340040093915"
6) "oval:org.debian:def:205400728072744866719207044776762665715"

// startup goval-dictionary server
$ goval-dictionary server --dbtype redis --dbpath "redis://127.0.0.1:6379/0"

// search debian 11 a2ps package
$ curl http://127.0.0.1:1324/packs/debian/11/a2ps | jq .

// goval-dictionary server log
EROR[12-08|14:26:50] Failed to HMGet. err: Some fields do not exist. continue scanning Family=debian Version=11 defID=oval:org.debian:def:test
{"time":"2021-12-08T14:26:50.764027005+09:00","id":"","remote_ip":"127.0.0.1","host":"127.0.0.1:1324","method":"GET","uri":"/packs/debian/11/a2ps","user_agent":"curl/7.68.0","status":200,"error":"","latency":4715455,"latency_human":"4.715455ms","bytes_in":0,"bytes_out":4380}

// log when searching again
{"time":"2021-12-08T14:26:55.510864892+09:00","id":"","remote_ip":"127.0.0.1","host":"127.0.0.1:1324","method":"GET","uri":"/packs/debian/11/a2ps","user_agent":"curl/7.68.0","status":200,"error":"","latency":689896,"latency_human":"689.896µs","bytes_in":0,"bytes_out":4380}

// check redis 
$ redis-cli -p 6379
127.0.0.1:6379> SMEMBERS OVAL#debian#11#PKG#a2ps
1) "oval:org.debian:def:75476148081331502013618590951901882535"
2) "oval:org.debian:def:88988697754130173838013832986587830139"
3) "oval:org.debian:def:89135559689250371593682731796707320194"
4) "oval:org.debian:def:287503723613106787615900001340040093915"
5) "oval:org.debian:def:205400728072744866719207044776762665715"
```
## cveid search
```console
// setup
$ redis-cli -p 6379
127.0.0.1:6379> SMEMBERS OVAL#debian#11#CVE#CVE-1999-0710
1) "oval:org.debian:def:test"
2) "oval:org.debian:def:109979686688988462524729939069328441860"

// startup goval-dictionary server
$ goval-dictionary server --dbtype redis --dbpath "redis://127.0.0.1:6379/0"

// search debian 11 CVE-2002-0659
$ curl http://127.0.0.1:1324/cves/debian/11/CVE-1999-0710 | jq .

// goval-dictionary server log
EROR[12-08|23:00:24] Failed to HMGet. err: Some fields do not exist. continue scanning Family=debian Version=11 defID=oval:org.debian:def:test
{"time":"2021-12-08T23:00:24.789503804+09:00","id":"","remote_ip":"127.0.0.1","host":"127.0.0.1:1324","method":"GET","uri":"/cves/debian/11/CVE-1999-0710","user_agent":"curl/7.68.0","status":200,"error":"","latency":4362152,"latency_human":"4.362152ms","bytes_in":0,"bytes_out":926}

// log when searching again
{"time":"2021-12-08T23:00:56.841072287+09:00","id":"","remote_ip":"127.0.0.1","host":"127.0.0.1:1324","method":"GET","uri":"/cves/debian/11/CVE-1999-0710","user_agent":"curl/7.68.0","status":200,"error":"","latency":837006,"latency_human":"837.006µs","bytes_in":0,"bytes_out":926}

// check redis 
$ redis-cli -p 6379
127.0.0.1:6379> SMEMBERS OVAL#debian#11#CVE#CVE-1999-0710
1) "oval:org.debian:def:235219172302950797077809285042175390515"
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
