### PR TITLE
feat(fetch): use CVE information in references

### DIFF
--- a/models/debian.go
+++ b/models/debian.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -21,16 +20,16 @@ func ConvertDebianToModel(root *oval.Root) (defs []Definition) {
 			continue
 		}
 
-		cve := Cve{}
-		if strings.HasPrefix(ovaldef.Title, "CVE-") {
-			cve = Cve{
-				CveID: ovaldef.Title,
-				Href:  fmt.Sprintf("https://cve.mitre.org/cgi-bin/cvename.cgi?name=%s", ovaldef.Title),
-			}
-		}
-
+		cves := []Cve{}
 		rs := []Reference{}
 		for _, r := range ovaldef.References {
+			if r.Source == "CVE" {
+				cves = append(cves, Cve{
+					CveID: r.RefID,
+					Href:  r.RefURL,
+				})
+			}
+
 			rs = append(rs, Reference{
 				Source: r.Source,
 				RefID:  r.RefID,
@@ -57,7 +56,7 @@ func ConvertDebianToModel(root *oval.Root) (defs []Definition) {
 			Description:  ovaldef.Description,
 			Advisory: Advisory{
 				Severity:        "",
-				Cves:            []Cve{cve},
+				Cves:            cves,
 				Bugzillas:       []Bugzilla{},
 				AffectedCPEList: []Cpe{},
 				Issued:          time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),

--- a/models/ubuntu.go
+++ b/models/ubuntu.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -17,17 +16,16 @@ func ConvertUbuntuToModel(root *oval.Root) (defs []Definition) {
 			continue
 		}
 
-		cve := Cve{}
-		cveID := strings.Split(d.Title, " ")[0]
-		if strings.HasPrefix(cveID, "CVE-") {
-			cve = Cve{
-				CveID: cveID,
-				Href:  fmt.Sprintf("https://cve.mitre.org/cgi-bin/cvename.cgi?name=%s", cveID),
-			}
-		}
-
+		cves := []Cve{}
 		rs := []Reference{}
 		for _, r := range d.References {
+			if r.Source == "CVE" {
+				cves = append(cves, Cve{
+					CveID: r.RefID,
+					Href:  r.RefURL,
+				})
+			}
+
 			rs = append(rs, Reference{
 				Source: r.Source,
 				RefID:  r.RefID,
@@ -55,7 +53,7 @@ func ConvertUbuntuToModel(root *oval.Root) (defs []Definition) {
 			Description:  d.Description,
 			Advisory: Advisory{
 				Severity:        d.Advisory.Severity,
-				Cves:            []Cve{cve},
+				Cves:            cves,
 				Bugzillas:       []Bugzilla{},
 				AffectedCPEList: []Cpe{},
 				Issued:          time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),


### PR DESCRIPTION
# What did you implement:
Debian used to have a title format of `"CVE-ID"`, but this has recently been changed to `"DSA-ID"` for Debian 7 and 8, and to `"CVE-ID PackageName"` for Debian 9, 10 and 11.
So Debian uses the `source="CVE"` information in References as cves.
Also, Ubuntu used to get CVEID by parse title, but to avoid this problem, get it from references.

Fixes #167

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## master
```console
$ goval-dictionary fetch debian 8
$ sqlite3 oval.sqlite3
sqlite> SELECT * FROM cves LIMIT 3;
id|advisory_id|cve_id|cvss2|cvss3|cwe|impact|href|public
1|1|||||||
2|2|||||||
3|3|||||||

$ goval-dictionary fetch debian 11
$ sqlite3 oval.sqlite3
sqlite> SELECT * FROM cves LIMIT 3;
id|advisory_id|cve_id|cvss2|cvss3|cwe|impact|href|public
1|1|CVE-1999-0199 glibc|||||https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0199 glibc|
2|2|CVE-1999-0710 squid|||||https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0710 squid|
3|3|CVE-1999-1332 gzip|||||https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-1332 gzip|
```

## MaineK00n/fix-fetch-cves
```console
$ goval-dictionary fetch debian 8
$ sqlite3 oval.sqlite3
sqlite> SELECT * FROM cves LIMIT 3;
id|advisory_id|cve_id|cvss2|cvss3|cwe|impact|href|public
1|1|CVE-2009-3555|||||https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3555|
2|1|CVE-2012-4929|||||https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-4929|
3|1|CVE-2014-3566|||||https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3566|

$ goval-dictionary fetch debian 11
$ sqlite3 oval.sqlite3
sqlite> SELECT * FROM cves LIMIT 3;
id|advisory_id|cve_id|cvss2|cvss3|cwe|impact|href|public
1|1|CVE-1999-0199|||||https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0199|
2|2|CVE-1999-0710|||||https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-0710|
3|3|CVE-1999-1332|||||https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-1999-1332|
```

## diff cveid (ubuntu)
```console
$ goval-dictionary.master fetch ubuntu --dbpath=$(PWD)/oval.master.sqlite3 14 16 18 19 20
$ goval-dictionary.pr fetch ubuntu --dbpath=$(PWD)/oval.pr.sqlite3 14 16 18 19 20
$ sqlite3 oval.master.sqlite3
sqlite> .output master_cveids.txt
sqlite> SELECT cve_id FROM cves ORDER BY cve_id;

$ sqlite3 oval.pr.sqlite3
sqlite> .output pr_cveids.txt
sqlite> SELECT cve_id FROM cves ORDER BY cve_id;

$ diff master_cveids.txt pr_cveids.txt 
1,5d0
< 
< 
< 
< 
< 
4265d4259
< CVE-2013-NNN1

```

CVE-2013-NNN1 is parseed from title, which is malformed.
```xml
<definition class="vulnerability" id="oval:com.ubuntu.trusty:def:201310000000" version="1">
    <metadata>
        <title>CVE-2013-NNN1 on Ubuntu 14.04 LTS (trusty) - low.</title>
        <description>The mysql-5.5 package misses the patches applied previous in Debian's mysql-5.1 to drop the database "test" and the permissions that allow anonymous access, without a password, from localhost to the "test" database and any databases starting with "test_". This update reintroduces these patches for the mysql-5.5 package.</description>
        <affected family="unix">
            <platform>Ubuntu 14.04 LTS</platform>
        </affected>
        <advisory>
            <severity>Low</severity>
            <rights>Copyright (C) 2013 Canonical Ltd.</rights>
            <public_date>2013-12-16</public_date>
            <assigned_to>mdeslaur</assigned_to>
            <discovered_by>Matthias Reichl</discovered_by>
            <bug>https://launchpad.net/bugs/1261529</bug>
            <bug>http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=732306</bug>
            <ref>http://people.canonical.com/~ubuntu-security/cve/2013/CVE-2013-NNN1.html</ref>
        </advisory>
    </metadata>
    <oval:notes>
        <oval:note>jdstrand&gt; Running mysql_secure_installation (generally recommended for production environments) will prompt to remove the 'test' database Affects new installations of mysql-5.5, not upgrades from mysql-5.1 and the Debian patch does not remove the 'test' database on upgrades (to prevent data loss).</oval:note>
    </oval:notes>
    <criteria>
        <extend_definition definition_ref="oval:com.ubuntu.trusty:def:100" comment="Ubuntu 14.04 LTS (trusty) is installed." applicability_check="true" />
        <criterion test_ref="oval:com.ubuntu.trusty:tst:201310000000" comment="mysql-5.5 package in trusty, is related to the CVE in some way and has been fixed (note: '5.5.35+dfsg-1ubuntu1')." />
    </criteria>
</definition>
```


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

