### PR TITLE
fix(redis): update Redis key relationship successfully

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,15 +31,15 @@ LDFLAGS := -X 'github.com/vulsio/goval-dictionary/config.Version=$(VERSION)' \
 GO := GO111MODULE=on go
 GO_OFF := GO111MODULE=off go
 
-all: build
+all: build test
 
-build: main.go pretest
+build: main.go
 	$(GO) build -a -ldflags "$(LDFLAGS)" -o goval-dictionary $<
 
-b: 	main.go pretest
+b: 	main.go
 	$(GO) build -ldflags "$(LDFLAGS)" -o goval-dictionary $<
 
-install: main.go pretest
+install: main.go
 	$(GO) install -ldflags "$(LDFLAGS)"
 
 lint:

--- a/db/redis.go
+++ b/db/redis.go
@@ -381,7 +381,7 @@ func (r *RedisDriver) InsertOval(root *models.Root) (err error) {
 			}
 		}
 		for pack := range definitions["packages"] {
-			if err := pipe.SRem(ctx, fmt.Sprintf(cveKeyFormat, family, osVer, pack), defID).Err(); err != nil {
+			if err := pipe.SRem(ctx, fmt.Sprintf(pkgKeyFormat, family, osVer, pack), defID).Err(); err != nil {
 				return xerrors.Errorf("Failed to SRem. err: %w", err)
 			}
 		}

--- a/db/redis.go
+++ b/db/redis.go
@@ -385,8 +385,10 @@ func (r *RedisDriver) InsertOval(root *models.Root) (err error) {
 				return xerrors.Errorf("Failed to SRem. err: %w", err)
 			}
 		}
-		if err := pipe.HDel(ctx, fmt.Sprintf(defKeyFormat, family, osVer), defID).Err(); err != nil {
-			return xerrors.Errorf("Failed to HDel. err: %w", err)
+		if _, ok := newDeps[defID]; !ok {
+			if err := pipe.HDel(ctx, fmt.Sprintf(defKeyFormat, family, osVer), defID).Err(); err != nil {
+				return xerrors.Errorf("Failed to HDel. err: %w", err)
+			}
 		}
 	}
 	newDepsJSON, err := json.Marshal(newDeps)


### PR DESCRIPTION
# What did you implement:
There was a bug in the update method of deleting outdated information in the DB at the time of Redis fetch, causing more information than necessary to be deleted.This bug has been fixed.

This is a bug related to #173, as it will break the key relationship in Redis.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## When the content associated with a previously fetched definition ID has been updated (verified by CVE-ID)
### master
```console
$ goval-dictionary fetch debian 11 --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> SMEMBERS OVAL#debian#11#CVE#CVE-2021-22204
1) "oval:org.debian:def:100020194192621893181231895146832483613"
127.0.0.1:6379> HGET OVAL#debian#11#DEF oval:org.debian:def:100020194192621893181231895146832483613
"{\"DefinitionID\":\"oval:org.debian:def:100020194192621893181231895146832483613\",\"Title\":\"CVE-2021-22204 libimage-exiftool-perl\",\"Description\":\"Improper neutralization of user data in the DjVu file format in ExifTool versions 7.44 and up allows arbitrary code execution when parsing the malicious image\",\"Advisory\":{\"Severity\":\"\",\"Cves\":[{\"CveID\":\"CVE-2021-22204\",\"Cvss2\":\"\",\"Cvss3\":\"\",\"Cwe\":\"\",\"Impact\":\"\",\"Href\":\"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22204\",\"Public\":\"\"}],\"Bugzillas\":[],\"AffectedCPEList\":[],\"Issued\":\"1000-01-01T00:00:00Z\",\"Updated\":\"1000-01-01T00:00:00Z\"},\"Debian\":{\"MoreInfo\":\"\",\"Date\":\"1000-01-01T00:00:00Z\"},\"AffectedPacks\":[{\"Name\":\"libimage-exiftool-perl\",\"Version\":\"12.16+dfsg-2\",\"Arch\":\"\",\"NotFixedYet\":false,\"ModularityLabel\":\"\"}],\"References\":[{\"Source\":\"CVE\",\"RefID\":\"CVE-2021-22204\",\"RefURL\":\"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22204\"}]}"
127.0.0.1:6379> SET OVAL#debian#11#DEP '{ "oval:org.debian:def:100020194192621893181231895146832483613": { "cves": { "CVE-2021-22204": {}, "test": {} }, "packages": { "libimage-exiftool-perl": {} } } }'
OK
127.0.0.1:6379> SADD OVAL#debian#11#CVE#test oval:org.debian:def:100020194192621893181231895146832483613
(integer) 1

$ goval-dictionary fetch debian 11 --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> SMEMBERS OVAL#debian#11#CVE#CVE-2021-22204
1) "oval:org.debian:def:100020194192621893181231895146832483613"
127.0.0.1:6379> SMEMBERS OVAL#debian#11#CVE#test
(empty array)
127.0.0.1:6379> EXISTS OVAL#debian#11#CVE#test
(integer) 0
127.0.0.1:6379> HGET OVAL#debian#11#DEF oval:org.debian:def:100020194192621893181231895146832483613
(nil) // bug
```

### MaineK00n/fix-update-deps
```console
$ goval-dictionary fetch debian 11 --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> SMEMBERS OVAL#debian#11#CVE#CVE-2021-22204
1) "oval:org.debian:def:100020194192621893181231895146832483613"
127.0.0.1:6379> HGET OVAL#debian#11#DEF oval:org.debian:def:100020194192621893181231895146832483613
"{\"DefinitionID\":\"oval:org.debian:def:100020194192621893181231895146832483613\",\"Title\":\"CVE-2021-22204 libimage-exiftool-perl\",\"Description\":\"Improper neutralization of user data in the DjVu file format in ExifTool versions 7.44 and up allows arbitrary code execution when parsing the malicious image\",\"Advisory\":{\"Severity\":\"\",\"Cves\":[{\"CveID\":\"CVE-2021-22204\",\"Cvss2\":\"\",\"Cvss3\":\"\",\"Cwe\":\"\",\"Impact\":\"\",\"Href\":\"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22204\",\"Public\":\"\"}],\"Bugzillas\":[],\"AffectedCPEList\":[],\"Issued\":\"1000-01-01T00:00:00Z\",\"Updated\":\"1000-01-01T00:00:00Z\"},\"Debian\":{\"MoreInfo\":\"\",\"Date\":\"1000-01-01T00:00:00Z\"},\"AffectedPacks\":[{\"Name\":\"libimage-exiftool-perl\",\"Version\":\"12.16+dfsg-2\",\"Arch\":\"\",\"NotFixedYet\":false,\"ModularityLabel\":\"\"}],\"References\":[{\"Source\":\"CVE\",\"RefID\":\"CVE-2021-22204\",\"RefURL\":\"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22204\"}]}"
127.0.0.1:6379> SET OVAL#debian#11#DEP '{ "oval:org.debian:def:100020194192621893181231895146832483613": { "cves": { "CVE-2021-22204": {}, "test": {} }, "packages": { "libimage-exiftool-perl": {} } } }'
OK
127.0.0.1:6379> SADD OVAL#debian#11#CVE#test oval:org.debian:def:100020194192621893181231895146832483613
(integer) 1

$ goval-dictionary fetch debian 11 --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> SMEMBERS OVAL#debian#11#CVE#CVE-2021-22204
1) "oval:org.debian:def:100020194192621893181231895146832483613"
127.0.0.1:6379> SMEMBERS OVAL#debian#11#CVE#test
(empty array)
127.0.0.1:6379> EXISTS OVAL#debian#11#CVE#test
(integer) 0
127.0.0.1:6379> HGET OVAL#debian#11#DEF oval:org.debian:def:100020194192621893181231895146832483613
"{\"DefinitionID\":\"oval:org.debian:def:100020194192621893181231895146832483613\",\"Title\":\"CVE-2021-22204 libimage-exiftool-perl\",\"Description\":\"Improper neutralization of user data in the DjVu file format in ExifTool versions 7.44 and up allows arbitrary code execution when parsing the malicious image\",\"Advisory\":{\"Severity\":\"\",\"Cves\":[{\"CveID\":\"CVE-2021-22204\",\"Cvss2\":\"\",\"Cvss3\":\"\",\"Cwe\":\"\",\"Impact\":\"\",\"Href\":\"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22204\",\"Public\":\"\"}],\"Bugzillas\":[],\"AffectedCPEList\":[],\"Issued\":\"1000-01-01T00:00:00Z\",\"Updated\":\"1000-01-01T00:00:00Z\"},\"Debian\":{\"MoreInfo\":\"\",\"Date\":\"1000-01-01T00:00:00Z\"},\"AffectedPacks\":[{\"Name\":\"libimage-exiftool-perl\",\"Version\":\"12.16+dfsg-2\",\"Arch\":\"\",\"NotFixedYet\":false,\"ModularityLabel\":\"\"}],\"References\":[{\"Source\":\"CVE\",\"RefID\":\"CVE-2021-22204\",\"RefURL\":\"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22204\"}]}"
```

## If a previously fetched definition ID does not exist in the newly fetched definition ID
### master
```console
$ goval-dictionary fetch debian 11 --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> SET OVAL#debian#11#DEP '{ "test": { "cves": { "test": {} }, "packages": { "test": {} } } }'
OK
127.0.0.1:6379> SADD OVAL#debian#11#CVE#test test
(integer) 1
127.0.0.1:6379> SADD OVAL#debian#11#PKG#test test
(integer) 1
127.0.0.1:6379> HSET OVAL#debian#11#DEF test {}
(integer) 1

$ goval-dictionary fetch debian 11 --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> SMEMBERS OVAL#debian#11#CVE#test
(empty array)
127.0.0.1:6379> EXISTS OVAL#debian#11#CVE#test
(integer) 0
127.0.0.1:6379> SMEMBERS OVAL#debian#11#PKG#test
1) "test" // bug
127.0.0.1:6379> EXISTS OVAL#debian#11#PKG#test
(integer) 1 // bug
127.0.0.1:6379> HGET OVAL#debian#11#DEF test
(nil)
```

### MaineK00n/fix-update-deps
```console
$ goval-dictionary fetch debian 11 --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> SET OVAL#debian#11#DEP '{ "test": { "cves": { "test": {} }, "packages": { "test": {} } } }'
OK
127.0.0.1:6379> SADD OVAL#debian#11#CVE#test test
(integer) 1
127.0.0.1:6379> SADD OVAL#debian#11#PKG#test test
(integer) 1
127.0.0.1:6379> HSET OVAL#debian#11#DEF test {}
(integer) 1

$ goval-dictionary fetch debian 11 --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> SMEMBERS OVAL#debian#11#CVE#test
(empty array)
127.0.0.1:6379> EXISTS OVAL#debian#11#CVE#test
(integer) 0
127.0.0.1:6379> SMEMBERS OVAL#debian#11#PKG#test
(empty array)
127.0.0.1:6379> EXISTS OVAL#debian#11#PKG#test
(integer) 0
127.0.0.1:6379> HGET OVAL#debian#11#DEF test
(nil)
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
