### PR TITLE
feat(db): add LastFetchedDate in fetchmeta

### DIFF
--- a/commands/fetch-alpine.go
+++ b/commands/fetch-alpine.go
@@ -115,7 +115,7 @@ func fetchAlpine(_ *cobra.Command, args []string) (err error) {
 		log15.Info("Finish", "Updated", len(root.Definitions))
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}

--- a/commands/fetch-alpine.go
+++ b/commands/fetch-alpine.go
@@ -63,8 +63,9 @@ func fetchAlpine(_ *cobra.Command, args []string) (err error) {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to Insert CVEs into DB. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
@@ -112,6 +113,11 @@ func fetchAlpine(_ *cobra.Command, args []string) (err error) {
 			return xerrors.Errorf("Failed to insert OVAL. err: %w", err)
 		}
 		log15.Info("Finish", "Updated", len(root.Definitions))
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
 
 	return nil

--- a/commands/fetch-amazon.go
+++ b/commands/fetch-amazon.go
@@ -104,7 +104,7 @@ func fetchAmazon(_ *cobra.Command, _ []string) (err error) {
 		return xerrors.Errorf("Failed to Insert Amazon2022. err: %w", err)
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}

--- a/commands/fetch-debian.go
+++ b/commands/fetch-debian.go
@@ -100,7 +100,7 @@ func fetchDebian(_ *cobra.Command, args []string) (err error) {
 		log15.Info("Finish", "Updated", len(root.Definitions))
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}

--- a/commands/fetch-debian.go
+++ b/commands/fetch-debian.go
@@ -57,6 +57,7 @@ func fetchDebian(_ *cobra.Command, args []string) (err error) {
 	if fetchMeta.OutDated() {
 		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
@@ -97,6 +98,11 @@ func fetchDebian(_ *cobra.Command, args []string) (err error) {
 			return xerrors.Errorf("Failed to insert OVAL. err: %w", err)
 		}
 		log15.Info("Finish", "Updated", len(root.Definitions))
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
 
 	return nil

--- a/commands/fetch-oracle.go
+++ b/commands/fetch-oracle.go
@@ -85,7 +85,7 @@ func fetchOracle(_ *cobra.Command, _ []string) (err error) {
 		log15.Info("Finish", "Updated", len(root.Definitions))
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}

--- a/commands/fetch-oracle.go
+++ b/commands/fetch-oracle.go
@@ -48,6 +48,7 @@ func fetchOracle(_ *cobra.Command, _ []string) (err error) {
 	if fetchMeta.OutDated() {
 		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
@@ -82,6 +83,11 @@ func fetchOracle(_ *cobra.Command, _ []string) (err error) {
 			return xerrors.Errorf("Failed to insert OVAL. err: %w", err)
 		}
 		log15.Info("Finish", "Updated", len(root.Definitions))
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
 
 	return nil

--- a/commands/fetch-redhat.go
+++ b/commands/fetch-redhat.go
@@ -96,7 +96,7 @@ func fetchRedHat(_ *cobra.Command, args []string) (err error) {
 		log15.Info("Finish", "Updated", len(root.Definitions))
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}

--- a/commands/fetch-suse.go
+++ b/commands/fetch-suse.go
@@ -118,7 +118,7 @@ func fetchSUSE(_ *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}

--- a/commands/fetch-suse.go
+++ b/commands/fetch-suse.go
@@ -89,6 +89,7 @@ func fetchSUSE(_ *cobra.Command, args []string) (err error) {
 	if fetchMeta.OutDated() {
 		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
@@ -115,6 +116,11 @@ func fetchSUSE(_ *cobra.Command, args []string) (err error) {
 			}
 			log15.Info("Finish", "Updated", len(root.Definitions))
 		}
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
 
 	return nil

--- a/commands/fetch-ubuntu.go
+++ b/commands/fetch-ubuntu.go
@@ -92,7 +92,7 @@ func fetchUbuntu(_ *cobra.Command, args []string) (err error) {
 		log15.Info("Finish", "Updated", len(root.Definitions))
 	}
 
-	fetchMeta.LastFetchedDate = time.Now()
+	fetchMeta.LastFetchedAt = time.Now()
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}

--- a/commands/fetch-ubuntu.go
+++ b/commands/fetch-ubuntu.go
@@ -52,6 +52,7 @@ func fetchUbuntu(_ *cobra.Command, args []string) (err error) {
 	if fetchMeta.OutDated() {
 		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
+	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
@@ -89,6 +90,11 @@ func fetchUbuntu(_ *cobra.Command, args []string) (err error) {
 			return xerrors.Errorf("Failed to insert OVAL. err: %w", err)
 		}
 		log15.Info("Finish", "Updated", len(root.Definitions))
+	}
+
+	fetchMeta.LastFetchedDate = time.Now()
+	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
+		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
 	}
 
 	return nil

--- a/commands/select.go
+++ b/commands/select.go
@@ -101,7 +101,7 @@ func executeSelect(_ *cobra.Command, args []string) error {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to Insert CVEs into DB. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to select command. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
 
 	if flagPkg {

--- a/commands/server.go
+++ b/commands/server.go
@@ -47,7 +47,7 @@ func executeServer(_ *cobra.Command, _ []string) (err error) {
 		return xerrors.Errorf("Failed to get FetchMeta from DB. err: %w", err)
 	}
 	if fetchMeta.OutDated() {
-		return xerrors.Errorf("Failed to start server. SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
+		return xerrors.Errorf("Failed to start server. err: SchemaVersion is old. SchemaVersion: %+v", map[string]uint{"latest": models.LatestSchemaVersion, "DB": fetchMeta.SchemaVersion})
 	}
 
 	log15.Info("Starting HTTP Server...")

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -356,7 +356,7 @@ func (r *RDBDriver) GetFetchMeta() (fetchMeta *models.FetchMeta, err error) {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
 		}
-		return &models.FetchMeta{GovalDictRevision: c.Revision, SchemaVersion: models.LatestSchemaVersion}, nil
+		return &models.FetchMeta{GovalDictRevision: c.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	return fetchMeta, nil

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -356,7 +356,7 @@ func (r *RDBDriver) GetFetchMeta() (fetchMeta *models.FetchMeta, err error) {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
 		}
-		return &models.FetchMeta{GovalDictRevision: c.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
+		return &models.FetchMeta{GovalDictRevision: c.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedAt: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	return fetchMeta, nil

--- a/db/redis.go
+++ b/db/redis.go
@@ -43,18 +43,18 @@ import (
   └───┴────────────────────────────────────────────────┴───────────────┴──────────────────────────────────────────┘
 
 - Hash
-  ┌───┬─────────────────────────────┬─────────────────┬───────────┬───────────────────────────────────────────┐
-  │NO │               KEY           │     FIELD       │   VALUE   │                PURPOSE                    │
-  └───┴─────────────────────────────┴─────────────────┴───────────┴───────────────────────────────────────────┘
-  ┌───┬─────────────────────────────┬─────────────────┬───────────┬───────────────────────────────────────────┐
-  │ 1 │ OVAL#$OSFAMILY#$VERSION#DEF │ $DEFINITIONID   │ $OVALJSON │ TO GET OVALJSON                           │
-  ├───┼─────────────────────────────┼─────────────────┼───────────┼───────────────────────────────────────────┤
-  │ 2 │ OVAL#FETCHMETA              │   Revision      │   string  │ GET Go-Oval-Disctionary Binary Revision   │
-  ├───┼─────────────────────────────┼─────────────────┼───────────┼───────────────────────────────────────────┤
-  │ 3 │ OVAL#FETCHMETA              │ SchemaVersion   │    uint   │ GET Go-Oval-Disctionary Schema Version    │
-  ├───┼─────────────────────────────┼─────────────────┼───────────┼───────────────────────────────────────────┤
-  │ 4 │ OVAL#FETCHMETA              │ LastFetchedDate │ time.Time │ GET Go-Oval-Disctionary Last Fetched Time │
-  └───┴─────────────────────────────┴─────────────────┴───────────┴───────────────────────────────────────────┘
+  ┌───┬─────────────────────────────┬───────────────┬───────────┬───────────────────────────────────────────┐
+  │NO │               KEY           │     FIELD     │   VALUE   │                PURPOSE                    │
+  └───┴─────────────────────────────┴───────────────┴───────────┴───────────────────────────────────────────┘
+  ┌───┬─────────────────────────────┬───────────────┬───────────┬───────────────────────────────────────────┐
+  │ 1 │ OVAL#$OSFAMILY#$VERSION#DEF │ $DEFINITIONID │ $OVALJSON │ TO GET OVALJSON                           │
+  ├───┼─────────────────────────────┼───────────────┼───────────┼───────────────────────────────────────────┤
+  │ 2 │ OVAL#FETCHMETA              │   Revision    │   string  │ GET Go-Oval-Disctionary Binary Revision   │
+  ├───┼─────────────────────────────┼───────────────┼───────────┼───────────────────────────────────────────┤
+  │ 3 │ OVAL#FETCHMETA              │ SchemaVersion │    uint   │ GET Go-Oval-Disctionary Schema Version    │
+  ├───┼─────────────────────────────┼───────────────┼───────────┼───────────────────────────────────────────┤
+  │ 4 │ OVAL#FETCHMETA              │ LastFetchedAt │ time.Time │ GET Go-Oval-Disctionary Last Fetched Time │
+  └───┴─────────────────────────────┴───────────────┴───────────┴───────────────────────────────────────────┘
 
   **/
 
@@ -479,7 +479,7 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to Exists. err: %w", err)
 	}
 	if exists == 0 {
-		return &models.FetchMeta{GovalDictRevision: c.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedDate: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
+		return &models.FetchMeta{GovalDictRevision: c.Revision, SchemaVersion: models.LatestSchemaVersion, LastFetchedAt: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)}, nil
 	}
 
 	revision, err := r.conn.HGet(ctx, fetchMetaKey, "Revision").Result()
@@ -496,10 +496,10 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to ParseUint. err: %w", err)
 	}
 
-	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedDate").Result()
+	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedAt").Result()
 	if err != nil {
 		if !errors.Is(err, redis.Nil) {
-			return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+			return nil, xerrors.Errorf("Failed to HGet LastFetchedAt. err: %w", err)
 		}
 		datestr = time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
 	}
@@ -508,10 +508,10 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 		return nil, xerrors.Errorf("Failed to Parse date. err: %w", err)
 	}
 
-	return &models.FetchMeta{GovalDictRevision: revision, SchemaVersion: uint(version), LastFetchedDate: date}, nil
+	return &models.FetchMeta{GovalDictRevision: revision, SchemaVersion: uint(version), LastFetchedAt: date}, nil
 }
 
 // UpsertFetchMeta upsert FetchMeta to Database
 func (r *RedisDriver) UpsertFetchMeta(fetchMeta *models.FetchMeta) error {
-	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": c.Revision, "SchemaVersion": models.LatestSchemaVersion, "LastFetchedDate": fetchMeta.LastFetchedDate}).Err()
+	return r.conn.HSet(context.Background(), fetchMetaKey, map[string]interface{}{"Revision": c.Revision, "SchemaVersion": models.LatestSchemaVersion, "LastFetchedAt": fetchMeta.LastFetchedAt}).Err()
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -498,7 +498,10 @@ func (r *RedisDriver) GetFetchMeta() (*models.FetchMeta, error) {
 
 	datestr, err := r.conn.HGet(ctx, fetchMetaKey, "LastFetchedDate").Result()
 	if err != nil {
-		return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+		if !errors.Is(err, redis.Nil) {
+			return nil, xerrors.Errorf("Failed to HGet LastFetchedDate. err: %w", err)
+		}
+		datestr = time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
 	}
 	date, err := time.Parse(time.RFC3339, datestr)
 	if err != nil {

--- a/models/models.go
+++ b/models/models.go
@@ -14,6 +14,7 @@ type FetchMeta struct {
 	gorm.Model        `json:"-"`
 	GovalDictRevision string
 	SchemaVersion     uint
+	LastFetchedDate   time.Time
 }
 
 // OutDated checks whether last fetched feed is out dated

--- a/models/models.go
+++ b/models/models.go
@@ -14,7 +14,7 @@ type FetchMeta struct {
 	gorm.Model        `json:"-"`
 	GovalDictRevision string
 	SchemaVersion     uint
-	LastFetchedDate   time.Time
+	LastFetchedAt     time.Time
 }
 
 // OutDated checks whether last fetched feed is out dated


### PR DESCRIPTION
# What did you implement:
Add the time when the fetch is completed to fetchmeta.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## RDB
```console
$ goval-dictionary fetch debian 11
$ sqlite3 oval.sqlite3  
sqlite> SELECT last_fetched_at FROM fetch_meta;
2021-12-26 09:59:50.637731453+09:00

$ goval-dictionary fetch debian 11
$ sqlite3 oval.sqlite3  
sqlite> SELECT last_fetched_at FROM fetch_meta;
2021-12-26 10:00:09.584155161+09:00
```

## Redis
```console
$ redis-cli -p 6379
127.0.0.1:6379> HGET OVAL#FETCHMETA LastFetchedAt
(nil)

$ goval-dictionary fetch debian 11 --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HGET OVAL#FETCHMETA LastFetchedAt
"2021-12-26T10:00:32.020588113+09:00"

$ goval-dictionary fetch debian 11 --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
$ redis-cli -p 6379
127.0.0.1:6379> HGET OVAL#FETCHMETA LastFetchedAt
"2021-12-26T10:00:51.932290379+09:00"
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
