### PR TITLE
fix(amazon): change mirror.list URL of AL2022

### DIFF
--- a/fetcher/amazon.go
+++ b/fetcher/amazon.go
@@ -17,7 +17,7 @@ import (
 const (
 	amazonLinux1MirrorListURI    = "http://repo.us-west-2.amazonaws.com/2018.03/updates/x86_64/mirror.list"
 	amazonLinux2MirrorListURI    = "https://cdn.amazonlinux.com/2/core/latest/x86_64/mirror.list"
-	amazonLinux2022MirrorListURI = "https://al2022-repos-us-east-1-9761ab97.s3.dualstack.us-east-1.amazonaws.com/core/mirrors/2022.0.20211118/x86_64/mirror.list"
+	amazonLinux2022MirrorListURI = "https://al2022-repos-us-east-1-9761ab97.s3.dualstack.us-east-1.amazonaws.com/core/mirrors/2022.0.20211210/x86_64/mirror.list"
 )
 
 // RepoMd has repomd data


### PR DESCRIPTION
# What did you implement:

The URL of mirror.list in Amazon Linux 2022 has been changed.
Since the immutable URL indicating latest is unknown, every time the URL is changed, I have to change the URL as in this pull request.
If anyone knows the immutable URL that shows the latest of the mirror.list of Amazon Linux 2022, please let me know.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
curl https://al2022-repos-us-east-1-9761ab97.s3.dualstack.us-east-1.amazonaws.com/core/guids/cdf9aafeacc2e5e1b39d59842558a197a28da245b7eaee4775741ba275d2a08c/x86_64/repodata/updateinfo.xml.gz | gunzip | less
```

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
