### PR TITLE
feat(al2022): fetch the latest updateInfo for al2022

### DIFF
--- a/fetcher/amazon.go
+++ b/fetcher/amazon.go
@@ -133,7 +133,7 @@ func getAmazonLinux2022MirrorListURI() (uri string, err error) {
 		versions = append(versions, release.Version)
 	}
 	if len(versions) == 0 {
-		return "", xerrors.Errorf("Failed to fetch releasemd.xml for AL2022. url: %s, err: %w", al2022ReleasemdURI, err)
+		return "", xerrors.Errorf("Failed to get the latest version of al2022. url: %s", al2022ReleasemdURI)
 	}
 	sort.Sort(sort.Reverse(sort.StringSlice(versions)))
 	return fmt.Sprintf("https://al2022-repos-us-east-1-9761ab97.s3.dualstack.us-east-1.amazonaws.com/core/mirrors/%s/x86_64/mirror.list", versions[0]), nil

--- a/fetcher/amazon.go
+++ b/fetcher/amazon.go
@@ -113,14 +113,13 @@ func FetchUpdateInfoAmazonLinux2022() (*UpdateInfo, error) {
 }
 
 func getAmazonLinux2022MirrorListURI() (uri string, err error) {
-	results, err := fetchFeedFiles([]fetchRequest{{
-		url: al2022ReleasemdURI}})
+	results, err := fetchFeedFiles([]fetchRequest{{url: al2022ReleasemdURI}})
 	if err != nil || len(results) != 1 {
 		return "", xerrors.Errorf("Failed to fetch releasemd.xml for AL2022. url: %s, err: %w", al2022ReleasemdURI, err)
 	}
 
 	var root Root
-	// Since the XML charset encoding is defined as `utf8`` instead of `utf-8``, the following error will occur if it do not define a CharsetReader.
+	// Since the XML charset encoding is defined as `utf8` instead of `utf-8`, the following error will occur if it do not set decoder.CharsetReader.
 	// `Failed to fetch updateinfo for Amazon Linux2022. err: xml: encoding "utf8" declared but Decoder.CharsetReader is nil`
 	decoder := xml.NewDecoder(bytes.NewReader(results[0].Body))
 	decoder.CharsetReader = charset.NewReaderLabel

--- a/fetcher/amazon.go
+++ b/fetcher/amazon.go
@@ -125,7 +125,7 @@ func getAmazonLinux2022MirrorListURI() (uri string, err error) {
 	decoder := xml.NewDecoder(bytes.NewReader(results[0].Body))
 	decoder.CharsetReader = charset.NewReaderLabel
 	if err := decoder.Decode(&root); err != nil {
-		return "", err
+		return "", xerrors.Errorf("Failed to decode releasemd.xml for AL2022. err: %w", err)
 	}
 
 	versions := []string{}

--- a/fetcher/util.go
+++ b/fetcher/util.go
@@ -24,7 +24,7 @@ type fetchRequest struct {
 	concurrently bool
 }
 
-//FetchResult has url and OVAL definitions
+// FetchResult has url and OVAL definitions
 type FetchResult struct {
 	Target string
 	URL    string


### PR DESCRIPTION
# What did you implement:

UpdateInfo for Amazon Linux 2022 was implemented in the pull request #169 #191 ,
But it was not designed to get the latest version of UpdateInfo.
Therefore, it was necessary to change the URL every time the base image was upgraded.
We found a way to show the latest version of UpdateInfo and implemented it. 
(Thanks for the info @wagde-orca )


```
curl https://al2022-repos-us-west-2-9761ab97.s3.dualstack.us-west-2.amazonaws.com/core/releasemd.xml |less
```

xml
```
<?xml version="1.0" encoding="utf8"?>
<root>
    <releases>
        <release version="2022.0.20211118">
            <update>
                <name>2022.0.20211124</name>
                <version_string>2022.0.20211124</version_string>
                <release_notes>https://aws.amazon.com</release_notes>
            </update>
            <update>
                <name>2022.0.20211201</name>
                <version_string>2022.0.20211201</version_string>
                <release_notes>https://aws.amazon.com</release_notes>
            </update>
            <update>
                <name>2022.0.20211210</name>
                <version_string>2022.0.20211210</version_string>
                <release_notes>https://aws.amazon.com</release_notes>
            </update>
            <update>
                <name>2022.0.20211217</name>
                <version_string>2022.0.20211217</version_string>
                <release_notes>https://aws.amazon.com</release_notes>
            </update>
            <update>
                <name>2022.0.20211222</name>
                <version_string>2022.0.20211222</version_string>
                <release_notes>https://aws.amazon.com</release_notes>
            </update>
        </release>
        <release version="2022.0.20211124">
            <update>
                <name>2022.0.20211217</name>
                <version_string>2022.0.20211217</version_string>
                <release_notes>https://aws.amazon.com</release_notes>
            </update>
            <update>
                <name>2022.0.20211222</name>
                <version_string>2022.0.20211222</version_string>
                <release_notes>https://aws.amazon.com</release_notes>
            </update>
        </release>
        <release version="2022.0.20211201">
            <update>
                <name>2022.0.20211210</name>
                <version_string>2022.0.20211210</version_string>
                <release_notes>https://aws.amazon.com</release_notes>
            </update>
            <update>
                <name>2022.0.20211217</name>
                <version_string>2022.0.20211217</version_string>
                <release_notes>https://aws.amazon.com</release_notes>
            </update>
            <update>
                <name>2022.0.20211222</name>
                <version_string>2022.0.20211222</version_string>
                <release_notes>https://aws.amazon.com</release_notes>
            </update>
        </release>
        <release version="2022.0.20211210">
            <update>
                <name>2022.0.20211217</name>
                <version_string>2022.0.20211217</version_string>
                <release_notes>https://aws.amazon.com</release_notes>
            </update>
            <update>
                <name>2022.0.20211222</name>
                <version_string>2022.0.20211222</version_string>
                <release_notes>https://aws.amazon.com</release_notes>
            </update>
        </release>
        <release version="2022.0.20211217">
            <update>
                <name>2022.0.20211222</name>
                <version_string>2022.0.20211222</version_string>
                <release_notes>https://aws.amazon.com</release_notes>
            </update>
        </release>
        <release version="2022.0.20211222"/>
    </releases>
</root>
```

Select the latest version from the releases version.
  => 2022.0.20211222

```
curl https://al2022-repos-us-east-1-9761ab97.s3.dualstack.us-east-1.amazonaws.com/core/mirrors/2022.0.20211222/x86_64/mirror.list 
https://al2022-repos-us-east-1-9761ab97.s3.dualstack.us-east-1.amazonaws.com/core/guids/bb488ea9f8d8433a44e74132b689d8e6f1439c9aa44a8bd4464be3452cdd2cb8/x86_64/⏎  
[10:17 AM] curl -s https://al2022-repos-us-east-1-9761ab97.s3.dualstack.us-east-1.amazonaws.com/core/guids/bb488ea9f8d8433a44e74132b689d8e6f1439c9aa44a8bd4464be3452cdd2cb8/x86_64/repodata/updateinfo.xml.gz | gunzip | head -n10
<?xml version="1.0" ?>
<updates><update author="linux-security@amazon.com" from="linux-security@amazon.com" status="final" type="security" version="1.4"><id>ALAS2022-2021-001</id><title>Amazon Linux 2022 - ALAS2022-2021-001: medium priority package update for vim</title><issued date="2021-10-26 02:25" /><updated date="2021-10-27 00:24" /><severity>medium</severity><description>Package updates are available for Amazon Linux 2022 that fix the following vulnerabilities:
CVE-2021-3875:
        2014661: CVE-2021-3875 vim: heap-based buffer overflow
There's an out-of-bounds read flaw in Vim's ex_docmd.c. An attacker who is capable of tricking a user into opening a specially crafted file could trigger an out-of-bounds read on a memmove operation, potentially causing an impact to application availability.

CVE-2021-3872:
        2016056: CVE-2021-3872 vim: heap-based buffer overflow in win_redr_status() drawscreen.c
An out-of-bounds write flaw was found in vim's drawscreen.c win_redr_status() function. This flaw allows an attacker to trick a user to open a crafted file with specific arguments in vim, triggering an out-of-bounds write. The highest threat from this vulnerability is to confidentiality, integrity, and system availability.
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

./goval-dictionary fetch amazon works fine.

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
