### PR TITLE
fix(rdb): change where query

### DIFF
--- a/db/rdb.go
+++ b/db/rdb.go
@@ -145,15 +145,15 @@ func (r *RDBDriver) GetByPackName(family, osVer, packName, arch string) ([]model
 
 	switch family {
 	case c.Debian:
-		q = q.Preload("Debian").Where("`packages`.`name` = ?", packName).Preload("AffectedPacks")
+		q = q.Preload("Debian").Where("packages.name = ?", packName).Preload("AffectedPacks")
 	case c.Amazon, c.Oracle:
 		if arch == "" {
-			q = q.Where("`packages`.`name` = ?", packName).Preload("AffectedPacks")
+			q = q.Where("packages.name = ?", packName).Preload("AffectedPacks")
 		} else {
-			q = q.Where("`packages`.`name` = ? AND `packages`.`arch` = ?", packName, arch).Preload("AffectedPacks", "arch = ?", arch)
+			q = q.Where("packages.name = ? AND packages.arch = ?", packName, arch).Preload("AffectedPacks", "arch = ?", arch)
 		}
 	default:
-		q = q.Where("`packages`.`name` = ?", packName).Preload("AffectedPacks")
+		q = q.Where("packages.name = ?", packName).Preload("AffectedPacks")
 	}
 
 	// Specify limit number to avoid `too many SQL variable`.


### PR DESCRIPTION
# What did you implement:
fix syntax error in query.

Fixes https://github.com/future-architect/vuls/issues/1357

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```console
$ goval-dictionary fetch debian --dbtype=postgres --dbpath="postgresql://mainek00n:password@localhost:5432/oval" 11
$ goval-dictionary.master server --dbtype=postgres --dbpath="postgresql://mainek00n:password@localhost:5432/oval"
INFO[01-24|02:19:26] Starting HTTP Server... 
INFO[01-24|02:19:26] Listening...                             URL=127.0.0.1:1324

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.6.3
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
⇨ http server started on 127.0.0.1:1324
EROR[01-24|02:19:40] Failed to get by Package Name.           err="ERROR: syntax error at or near \".\" (SQLSTATE 42601)"
{"time":"2022-01-24T02:19:40.69934652+09:00","id":"","remote_ip":"127.0.0.1","host":"127.0.0.1:1324","method":"GET","uri":"/packs/debian/11/bash","user_agent":"curl/7.68.0","status":200,"error":"","latency":1136206,"latency_human":"1.136206ms","bytes_in":0,"bytes_out":5}

$ curl http://127.0.0.1:1324/packs/debian/11/bash | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     5  100     5    0     0   2500      0 --:--:-- --:--:-- --:--:--  2500
null

$ goval-dictionary.pr server --dbtype=postgres --dbpath="postgresql://mainek00n:password@localhost:5432/oval"
INFO[01-24|02:19:50] Starting HTTP Server... 
INFO[01-24|02:19:50] Listening...                             URL=127.0.0.1:1324

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.1.17
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
⇨ http server started on 127.0.0.1:1324
{"time":"2022-01-24T02:19:52.540364424+09:00","id":"","remote_ip":"127.0.0.1","host":"127.0.0.1:1324","method":"GET","uri":"/packs/debian/11/bash","user_agent":"curl/7.68.0","status":200,"error":"","latency":12909203,"latency_human":"12.909203ms","bytes_in":0,"bytes_out":16257}

$ curl http://127.0.0.1:1324/packs/debian/11/bash | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 16257    0 16257    0     0  1133k      0 --:--:-- --:--:-- --:--:-- 1133k
[
  {
    "DefinitionID": "oval:org.debian:def:104452954611053805468881680603569149504",
    "Title": "CVE-2008-5374 bash",
    "Description": "bash-doc 3.2 allows local users to overwrite arbitrary files via a symlink attack on a /tmp/cb#####.? temporary file, related to the (1) aliasconv.sh, (2) aliasconv.bash, and (3) cshtobash scripts.",
    "Advisory": {
      "Severity": "",
      "Cves": [
        {
          "CveID": "CVE-2008-5374",
          "Cvss2": "",
          "Cvss3": "",
          "Cwe": "",
          "Impact": "",
          "Href": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-5374",
          "Public": ""
        }
      ],
...
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

