### PR TITLE
fix(ubuntu): change OVAL URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ $ goval-dictionary fetch debian 7 8 9 10 11
 
 #### Usage: Fetch OVAL data from Ubuntu
 
-- [Ubuntu](https://people.canonical.com/~ubuntu-security/oval/)
+- [Ubuntu(main)](https://security-metadata.canonical.com/oval/)
+- [Ubuntu(sub)](https://people.canonical.com/~ubuntu-security/oval/)
 
 ```bash
 $ goval-dictionary fetch ubuntu 14 16 18 19 20 21
@@ -723,7 +724,8 @@ see [#7](https://github.com/vulsio/goval-dictionary/pull/7)
 
 - [RedHat](https://www.redhat.com/security/data/oval/)
 - [Debian](https://www.debian.org/security/oval/)
-- [Ubuntu](https://people.canonical.com/~ubuntu-security/oval/)
+- [Ubuntu(main)](https://security-metadata.canonical.com/oval/)
+- [Ubuntu(sub)](https://people.canonical.com/~ubuntu-security/oval/)
 - [SUSE](http://ftp.suse.com/pub/projects/security/oval/)
 - [Oracle Linux](https://linux.oracle.com/security/oval/)
 - [Alpine-secdb](https://secdb.alpinelinux.org/)

--- a/fetcher/ubuntu.go
+++ b/fetcher/ubuntu.go
@@ -9,45 +9,46 @@ import (
 )
 
 func newUbuntuFetchRequests(target []string) (reqs []fetchRequest) {
-	const t = "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.%s.cve.oval.xml.bz2"
 	for _, v := range target {
-		var name string
-		if name = ubuntuName(v); name == "unknown" {
+		switch url := getUbuntuOVALURL(v); url {
+		case "unknown":
 			log15.Warn("Skip unknown ubuntu.", "version", v)
-			continue
-		} else if name = ubuntuName(v); name == "unsupported" {
+		case "unsupported":
 			log15.Warn("Skip unsupported ubuntu version.", "version", v)
 			log15.Warn("See https://wiki.ubuntu.com/Releases for supported versions")
-			continue
+		default:
+			reqs = append(reqs, fetchRequest{
+				target:       v,
+				url:          url,
+				concurrently: true,
+				bzip2:        true,
+			})
 		}
-		reqs = append(reqs, fetchRequest{
-			target:       v,
-			url:          fmt.Sprintf(t, name),
-			concurrently: true,
-			bzip2:        true,
-		})
 	}
 	return
 }
 
-func ubuntuName(major string) string {
+func getUbuntuOVALURL(major string) string {
+	const main = "https://security-metadata.canonical.com/oval/com.ubuntu.%s.cve.oval.xml.bz2"
+	const sub = "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.%s.cve.oval.xml.bz2"
+
 	switch major {
 	case "12":
 		return "unsupported"
 	case "14":
-		return config.Ubuntu14
+		return fmt.Sprintf(main, config.Ubuntu14)
 	case "16":
-		return config.Ubuntu16
+		return fmt.Sprintf(main, config.Ubuntu16)
 	case "17":
 		return "unsupported"
 	case "18":
-		return config.Ubuntu18
+		return fmt.Sprintf(main, config.Ubuntu18)
 	case "19":
-		return config.Ubuntu19
+		return fmt.Sprintf(sub, config.Ubuntu19)
 	case "20":
-		return config.Ubuntu20
+		return fmt.Sprintf(main, config.Ubuntu20)
 	case "21":
-		return config.Ubuntu21
+		return fmt.Sprintf(main, config.Ubuntu21)
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
# What did you implement:
Fixes #190 

It seems that we can fetch information about new CVEs by changing the URL of OVAL.
This is the case of CVE-2021-4034 that we encountered.
```console
$ date
Fri 28 Jan 22:01:09 JST 2022

$ goval-dictionary.master version
goval-dictionary v0.6.0 b6263e5
$ goval-dictionary.master fetch ubuntu 20
$ goval-dictionary.master select --by-cveid ubuntu 20 CVE-2021-4034
------------------
[]models.Definition{}

$ goval-dictionary.pr version
goval-dictionary v0.6.0 23e2856
$ goval-dictionary.pr fetch ubuntu 20
$ goval-dictionary.pr select --by-cveid ubuntu 20 CVE-2021-4034
CVE-2021-4034 on Ubuntu 20.04 (focal) - high.
[{7853 7854 CVE-2021-4034     https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-4034 }]
------------------
[]models.Definition{
  models.Definition{
    ID:           0x1eae,
    RootID:       0x1,
    DefinitionID: "oval:com.ubuntu.focal:def:202140340000000",
    Title:        "CVE-2021-4034 on Ubuntu 20.04 (focal) - high.",
    Description:  "Local Privilege Escalation in polkit's pkexec",
    Advisory:     models.Advisory{
      ID:           0x1eae,
      DefinitionID: 0x1eae,
      Severity:     "High",
      Cves:         []models.Cve{
        models.Cve{
          ID:         0x1ead,
          AdvisoryID: 0x1eae,
          CveID:      "CVE-2021-4034",
          Cvss2:      "",
          Cvss3:      "",
          Cwe:        "",
          Impact:     "",
          Href:       "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-4034",
          Public:     "",
        },
      },
      Bugzillas:       []models.Bugzilla{},
      AffectedCPEList: []models.Cpe{},
      Issued:          1000-01-01 00:00:00 UTC,
      Updated:         1000-01-01 00:00:00 UTC,
    },
    Debian:        (*models.Debian)(nil),
    AffectedPacks: []models.Package{
      models.Package{
        ID:              0x57af,
        DefinitionID:    0x1eae,
        Name:            "policykit-1",
        Version:         "0.105-26ubuntu1.2",
        Arch:            "",
        NotFixedYet:     false,
        ModularityLabel: "",
      },
    },
    References: []models.Reference{
      models.Reference{
        ID:           0x8c17,
        DefinitionID: 0x1eae,
        Source:       "CVE",
        RefID:        "CVE-2021-4034",
        RefURL:       "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-4034",
      },
      models.Reference{
        ID:           0x8c18,
        DefinitionID: 0x1eae,
        Source:       "Ref",
        RefID:        "",
        RefURL:       "http://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-4034.html",
      },
      models.Reference{
        ID:           0x8c19,
        DefinitionID: 0x1eae,
        Source:       "Ref",
        RefID:        "",
        RefURL:       "https://www.qualys.com/2022/01/25/cve-2021-4034/pwnkit.txt",
      },
      models.Reference{
        ID:           0x8c1a,
        DefinitionID: 0x1eae,
        Source:       "Ref",
        RefID:        "",
        RefURL:       "https://ubuntu.com/security/notices/USN-5252-1",
      },
      models.Reference{
        ID:           0x8c1b,
        DefinitionID: 0x1eae,
        Source:       "Ref",
        RefID:        "",
        RefURL:       "https://ubuntu.com/security/notices/USN-5252-2",
      },
    },
  },
}
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
The number of definitions to be fetched for each is as follows.
Ubuntu19 has the same number as master because OVAL has not been released with the new URL.
|                   ubuntu                  |   14  |   16  |   18  |  19  |  20  |  21  |
|:-----------------------------------------:|:-----:|:-----:|:-----:|:----:|:----:|:----:|
|              master(b6263e5)              | 21482 | 19271 | 13959 | 6385 | 8933 | 7897 |
| MaineK00n/change-ubuntu-oval-url(23e2856) | 22100 | 19942 | 14618 | 6385 | 9491 | 8226 |

```console
$ goval-dictionary.master version
goval-dictionary v0.6.0 b6263e5

$ goval-dictionary.master fetch ubuntu 14 16 18 19 20 21
INFO[01-28|21:41:51] Fetching...                              URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml.bz2
INFO[01-28|21:41:51] Fetching...                              URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml.bz2
INFO[01-28|21:41:51] Fetching...                              URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.bionic.cve.oval.xml.bz2
INFO[01-28|21:41:51] Fetching...                              URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.eoan.cve.oval.xml.bz2
INFO[01-28|21:41:51] Fetching...                              URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.focal.cve.oval.xml.bz2
INFO[01-28|21:41:51] Fetching...                              URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.hirsute.cve.oval.xml.bz2
INFO[01-28|21:41:59] Fetched...                               URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.hirsute.cve.oval.xml.bz2
INFO[01-28|21:41:59] Fetched...                               URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.eoan.cve.oval.xml.bz2
INFO[01-28|21:41:59] Fetched...                               URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.focal.cve.oval.xml.bz2
INFO[01-28|21:41:59] Fetched...                               URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml.bz2
INFO[01-28|21:41:59] Fetched...                               URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.bionic.cve.oval.xml.bz2
INFO[01-28|21:41:59] Fetched...                               URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml.bz2
INFO[01-28|21:41:59] Finished fetching OVAL definitions 
INFO[01-28|21:42:00] Fetched                                  URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.hirsute.cve.oval.xml.bz2 OVAL definitions=7897
INFO[01-28|21:42:00] Refreshing...                            Family=ubuntu Version=21
INFO[01-28|21:42:00] Inserting new Definitions... 
7897 / 7897 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 40353 p/s
INFO[01-28|21:42:00] Finish                                   Updated=7897
INFO[01-28|21:42:01] Fetched                                  URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.eoan.cve.oval.xml.bz2 OVAL definitions=6393
INFO[01-28|21:42:01] Refreshing...                            Family=ubuntu Version=19
INFO[01-28|21:42:01] Inserting new Definitions... 
6385 / 6385 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 36741 p/s
INFO[01-28|21:42:02] Finish                                   Updated=6385
INFO[01-28|21:42:02] Fetched                                  URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.focal.cve.oval.xml.bz2 OVAL definitions=8935
INFO[01-28|21:42:03] Refreshing...                            Family=ubuntu Version=20
INFO[01-28|21:42:03] Inserting new Definitions... 
8933 / 8933 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 25101 p/s
INFO[01-28|21:42:04] Finish                                   Updated=8933
INFO[01-28|21:42:05] Fetched                                  URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml.bz2 OVAL definitions=19299
INFO[01-28|21:42:06] Refreshing...                            Family=ubuntu Version=16
INFO[01-28|21:42:06] Inserting new Definitions... 
19271 / 19271 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 23221 p/s
INFO[01-28|21:42:07] Finish                                   Updated=19271
INFO[01-28|21:42:09] Fetched                                  URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.bionic.cve.oval.xml.bz2 OVAL definitions=13979
INFO[01-28|21:42:10] Refreshing...                            Family=ubuntu Version=18
INFO[01-28|21:42:10] Inserting new Definitions... 
13959 / 13959 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 20072 p/s
INFO[01-28|21:42:11] Finish                                   Updated=13959
INFO[01-28|21:42:12] Fetched                                  URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.trusty.cve.oval.xml.bz2 OVAL definitions=21547
INFO[01-28|21:42:13] Refreshing...                            Family=ubuntu Version=14
INFO[01-28|21:42:13] Inserting new Definitions... 
21482 / 21482 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 26424 p/s
INFO[01-28|21:42:14] Finish                                   Updated=21482

$ goval-dictionary.pr version
goval-dictionary v0.6.0 23e2856

$ goval-dictionary.pr fetch ubuntu 14 16 18 19 20 21
INFO[01-28|21:42:34] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.focal.cve.oval.xml.bz2
INFO[01-28|21:42:34] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.hirsute.cve.oval.xml.bz2
INFO[01-28|21:42:34] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.trusty.cve.oval.xml.bz2
INFO[01-28|21:42:34] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.xenial.cve.oval.xml.bz2
INFO[01-28|21:42:34] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.bionic.cve.oval.xml.bz2
INFO[01-28|21:42:34] Fetching...                              URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.eoan.cve.oval.xml.bz2
INFO[01-28|21:42:40] Fetched...                               URL=https://security-metadata.canonical.com/oval/com.ubuntu.hirsute.cve.oval.xml.bz2
INFO[01-28|21:42:40] Fetched...                               URL=https://security-metadata.canonical.com/oval/com.ubuntu.focal.cve.oval.xml.bz2
INFO[01-28|21:42:40] Fetched...                               URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.eoan.cve.oval.xml.bz2
INFO[01-28|21:42:40] Fetched...                               URL=https://security-metadata.canonical.com/oval/com.ubuntu.bionic.cve.oval.xml.bz2
INFO[01-28|21:42:40] Fetched...                               URL=https://security-metadata.canonical.com/oval/com.ubuntu.xenial.cve.oval.xml.bz2
INFO[01-28|21:42:40] Fetched...                               URL=https://security-metadata.canonical.com/oval/com.ubuntu.trusty.cve.oval.xml.bz2
INFO[01-28|21:42:40] Finished fetching OVAL definitions 
INFO[01-28|21:42:40] Fetched                                  URL=https://security-metadata.canonical.com/oval/com.ubuntu.hirsute.cve.oval.xml.bz2 OVAL definitions=8226
INFO[01-28|21:42:40] Refreshing...                            Family=ubuntu Version=21
INFO[01-28|21:42:40] Inserting new Definitions... 
8226 / 8226 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 37574 p/s
INFO[01-28|21:42:41] Finish                                   Updated=8226
INFO[01-28|21:42:42] Fetched                                  URL=https://security-metadata.canonical.com/oval/com.ubuntu.focal.cve.oval.xml.bz2 OVAL definitions=9503
INFO[01-28|21:42:42] Refreshing...                            Family=ubuntu Version=20
INFO[01-28|21:42:42] Inserting new Definitions... 
9491 / 9491 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 24773 p/s
INFO[01-28|21:42:43] Finish                                   Updated=9491
INFO[01-28|21:42:44] Fetched                                  URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.eoan.cve.oval.xml.bz2 OVAL definitions=6393
INFO[01-28|21:42:44] Refreshing...                            Family=ubuntu Version=19
INFO[01-28|21:42:44] Inserting new Definitions... 
6385 / 6385 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 48183 p/s
INFO[01-28|21:42:44] Finish                                   Updated=6385
INFO[01-28|21:42:45] Fetched                                  URL=https://security-metadata.canonical.com/oval/com.ubuntu.bionic.cve.oval.xml.bz2 OVAL definitions=14648
INFO[01-28|21:42:47] Refreshing...                            Family=ubuntu Version=18
INFO[01-28|21:42:47] Inserting new Definitions... 
14618 / 14618 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 20562 p/s
INFO[01-28|21:42:48] Finish                                   Updated=14618
INFO[01-28|21:42:49] Fetched                                  URL=https://security-metadata.canonical.com/oval/com.ubuntu.xenial.cve.oval.xml.bz2 OVAL definitions=19980
INFO[01-28|21:42:50] Refreshing...                            Family=ubuntu Version=16
INFO[01-28|21:42:50] Inserting new Definitions... 
19942 / 19942 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 23160 p/s
INFO[01-28|21:42:52] Finish                                   Updated=19942
INFO[01-28|21:42:53] Fetched                                  URL=https://security-metadata.canonical.com/oval/com.ubuntu.trusty.cve.oval.xml.bz2 OVAL definitions=22175
INFO[01-28|21:42:54] Refreshing...                            Family=ubuntu Version=14
INFO[01-28|21:42:54] Inserting new Definitions... 
22100 / 22100 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 26065 p/s
INFO[01-28|21:42:56] Finish                                   Updated=22100
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

