### PR TITLE
feat(fetch): show timestamps of fetched OVAL files and warn if it hasn't been updated in 3 days

### DIFF
--- a/commands/fetch-debian.go
+++ b/commands/fetch-debian.go
@@ -90,7 +90,7 @@ func fetchDebian(_ *cobra.Command, args []string) (err error) {
 		log15.Info("Fetched", "File", r.URL[strings.LastIndex(r.URL, "/")+1:], "Count", len(ovalroot.Definitions.Definitions), "Timestamp", ovalroot.Generator.Timestamp)
 		ts, err := time.Parse("2006-01-02T15:04:05.999-07:00", ovalroot.Generator.Timestamp)
 		if err != nil {
-			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, err, ovalroot.Generator.Timestamp)
+			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, ovalroot.Generator.Timestamp, err)
 		}
 		if ts.Before(time.Now().AddDate(0, 0, -3)) {
 			log15.Warn("The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue.", "GitHub", "https://github.com/vulsio/goval-dictionary/issues", "OVAL", r.URL, "Timestamp", ovalroot.Generator.Timestamp)

--- a/commands/fetch-debian.go
+++ b/commands/fetch-debian.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"encoding/xml"
+	"strings"
 	"time"
 
 	"github.com/inconshreveable/log15"
@@ -85,7 +86,15 @@ func fetchDebian(_ *cobra.Command, args []string) (err error) {
 		if err := decoder.Decode(&ovalroot); err != nil {
 			return xerrors.Errorf("Failed to unmarshal xml. url: %s, err: %w", r.URL, err)
 		}
-		log15.Info("Fetched", "URL", r.URL, "OVAL definitions", len(ovalroot.Definitions.Definitions))
+
+		log15.Info("Fetched", "File", r.URL[strings.LastIndex(r.URL, "/")+1:], "Count", len(ovalroot.Definitions.Definitions), "Timestamp", ovalroot.Generator.Timestamp)
+		ts, err := time.Parse("2006-01-02T15:04:05.999-07:00", ovalroot.Generator.Timestamp)
+		if err != nil {
+			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, err, ovalroot.Generator.Timestamp)
+		}
+		if ts.Before(time.Now().AddDate(0, 0, -3)) {
+			log15.Warn("The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue.", "GitHub", "https://github.com/vulsio/goval-dictionary/issues", "OVAL", r.URL, "Timestamp", ovalroot.Generator.Timestamp)
+		}
 
 		root := models.Root{
 			Family:      c.Debian,

--- a/commands/fetch-oracle.go
+++ b/commands/fetch-oracle.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"encoding/xml"
+	"strings"
 	"time"
 
 	"github.com/inconshreveable/log15"
@@ -64,7 +65,14 @@ func fetchOracle(_ *cobra.Command, _ []string) (err error) {
 		if err = xml.Unmarshal(r.Body, &ovalroot); err != nil {
 			return xerrors.Errorf("Failed to unmarshal xml. url: %s, err: %w", r.URL, err)
 		}
-		log15.Info("Fetched", "URL", r.URL, "OVAL definitions", len(ovalroot.Definitions.Definitions))
+		log15.Info("Fetched", "File", r.URL[strings.LastIndex(r.URL, "/")+1:], "Count", len(ovalroot.Definitions.Definitions), "Timestamp", ovalroot.Generator.Timestamp)
+		ts, err := time.Parse("2006-01-02T15:04:05", ovalroot.Generator.Timestamp)
+		if err != nil {
+			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, err, ovalroot.Generator.Timestamp)
+		}
+		if ts.Before(time.Now().AddDate(0, 0, -3)) {
+			log15.Warn("The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue.", "GitHub", "https://github.com/vulsio/goval-dictionary/issues", "OVAL", r.URL, "Timestamp", ovalroot.Generator.Timestamp)
+		}
 
 		for osVer, defs := range models.ConvertOracleToModel(&ovalroot) {
 			osVerDefs[osVer] = append(osVerDefs[osVer], defs...)

--- a/commands/fetch-oracle.go
+++ b/commands/fetch-oracle.go
@@ -68,7 +68,7 @@ func fetchOracle(_ *cobra.Command, _ []string) (err error) {
 		log15.Info("Fetched", "File", r.URL[strings.LastIndex(r.URL, "/")+1:], "Count", len(ovalroot.Definitions.Definitions), "Timestamp", ovalroot.Generator.Timestamp)
 		ts, err := time.Parse("2006-01-02T15:04:05", ovalroot.Generator.Timestamp)
 		if err != nil {
-			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, err, ovalroot.Generator.Timestamp)
+			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, ovalroot.Generator.Timestamp, err)
 		}
 		if ts.Before(time.Now().AddDate(0, 0, -3)) {
 			log15.Warn("The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue.", "GitHub", "https://github.com/vulsio/goval-dictionary/issues", "OVAL", r.URL, "Timestamp", ovalroot.Generator.Timestamp)

--- a/commands/fetch-redhat.go
+++ b/commands/fetch-redhat.go
@@ -87,7 +87,7 @@ func fetchRedHat(_ *cobra.Command, args []string) (err error) {
 		log15.Info("Fetched", "File", r.URL[strings.LastIndex(r.URL, "/")+1:], "Count", len(ovalroot.Definitions.Definitions), "Timestamp", ovalroot.Generator.Timestamp)
 		ts, err := time.Parse("2006-01-02T15:04:05", ovalroot.Generator.Timestamp)
 		if err != nil {
-			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, err, ovalroot.Generator.Timestamp)
+			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, ovalroot.Generator.Timestamp, err)
 		}
 		if ts.Before(time.Now().AddDate(0, 0, -3)) {
 			log15.Warn("The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue.", "GitHub", "https://github.com/vulsio/goval-dictionary/issues", "OVAL", r.URL, "Timestamp", ovalroot.Generator.Timestamp)

--- a/commands/fetch-redhat.go
+++ b/commands/fetch-redhat.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/xml"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/inconshreveable/log15"
@@ -82,7 +83,16 @@ func fetchRedHat(_ *cobra.Command, args []string) (err error) {
 		if err = xml.Unmarshal(r.Body, &ovalroot); err != nil {
 			return xerrors.Errorf("Failed to unmarshal xml. url: %s, err: %w", r.URL, err)
 		}
-		log15.Info("Fetched", "URL", r.URL, "OVAL definitions", len(ovalroot.Definitions.Definitions))
+
+		log15.Info("Fetched", "File", r.URL[strings.LastIndex(r.URL, "/")+1:], "Count", len(ovalroot.Definitions.Definitions), "Timestamp", ovalroot.Generator.Timestamp)
+		ts, err := time.Parse("2006-01-02T15:04:05", ovalroot.Generator.Timestamp)
+		if err != nil {
+			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, err, ovalroot.Generator.Timestamp)
+		}
+		if ts.Before(time.Now().AddDate(0, 0, -3)) {
+			log15.Warn("The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue.", "GitHub", "https://github.com/vulsio/goval-dictionary/issues", "OVAL", r.URL, "Timestamp", ovalroot.Generator.Timestamp)
+		}
+
 		root := models.Root{
 			Family:      c.RedHat,
 			OSVersion:   r.Target,

--- a/commands/fetch-suse.go
+++ b/commands/fetch-suse.go
@@ -105,7 +105,14 @@ func fetchSUSE(_ *cobra.Command, args []string) (err error) {
 		if err = xml.Unmarshal(r.Body, &ovalroot); err != nil {
 			return xerrors.Errorf("Failed to unmarshal xml. url: %s, err: %w", r.URL, err)
 		}
-		log15.Info("Fetched", "URL", r.URL, "OVAL definitions", len(ovalroot.Definitions.Definitions))
+		log15.Info("Fetched", "File", r.URL[strings.LastIndex(r.URL, "/")+1:], "Count", len(ovalroot.Definitions.Definitions), "Timestamp", ovalroot.Generator.Timestamp)
+		ts, err := time.Parse("2006-01-02T15:04:05", ovalroot.Generator.Timestamp)
+		if err != nil {
+			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, err, ovalroot.Generator.Timestamp)
+		}
+		if ts.Before(time.Now().AddDate(0, 0, -3)) {
+			log15.Warn("The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue.", "GitHub", "https://github.com/vulsio/goval-dictionary/issues", "OVAL", r.URL, "Timestamp", ovalroot.Generator.Timestamp)
+		}
 
 		ss := strings.Split(r.URL, "/")
 		roots := models.ConvertSUSEToModel(ss[len(ss)-1], &ovalroot)

--- a/commands/fetch-suse.go
+++ b/commands/fetch-suse.go
@@ -108,7 +108,7 @@ func fetchSUSE(_ *cobra.Command, args []string) (err error) {
 		log15.Info("Fetched", "File", r.URL[strings.LastIndex(r.URL, "/")+1:], "Count", len(ovalroot.Definitions.Definitions), "Timestamp", ovalroot.Generator.Timestamp)
 		ts, err := time.Parse("2006-01-02T15:04:05", ovalroot.Generator.Timestamp)
 		if err != nil {
-			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, err, ovalroot.Generator.Timestamp)
+			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, ovalroot.Generator.Timestamp, err)
 		}
 		if ts.Before(time.Now().AddDate(0, 0, -3)) {
 			log15.Warn("The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue.", "GitHub", "https://github.com/vulsio/goval-dictionary/issues", "OVAL", r.URL, "Timestamp", ovalroot.Generator.Timestamp)

--- a/commands/fetch-ubuntu.go
+++ b/commands/fetch-ubuntu.go
@@ -82,7 +82,7 @@ func fetchUbuntu(_ *cobra.Command, args []string) (err error) {
 		log15.Info("Fetched", "File", r.URL[strings.LastIndex(r.URL, "/")+1:], "Count", len(ovalroot.Definitions.Definitions), "Timestamp", ovalroot.Generator.Timestamp)
 		ts, err := time.Parse("2006-01-02T15:04:05", ovalroot.Generator.Timestamp)
 		if err != nil {
-			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, err, ovalroot.Generator.Timestamp)
+			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, ovalroot.Generator.Timestamp, err)
 		}
 		if ts.Before(time.Now().AddDate(0, 0, -3)) {
 			log15.Warn("The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue.", "GitHub", "https://github.com/vulsio/goval-dictionary/issues", "OVAL", r.URL, "Timestamp", ovalroot.Generator.Timestamp)

--- a/commands/fetch-ubuntu.go
+++ b/commands/fetch-ubuntu.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"encoding/xml"
+	"strings"
 	"time"
 
 	"github.com/inconshreveable/log15"
@@ -77,7 +78,15 @@ func fetchUbuntu(_ *cobra.Command, args []string) (err error) {
 		if err = xml.Unmarshal(r.Body, &ovalroot); err != nil {
 			return xerrors.Errorf("Failed to unmarshal xml. url: %s, err: %w", r.URL, err)
 		}
-		log15.Info("Fetched", "URL", r.URL, "OVAL definitions", len(ovalroot.Definitions.Definitions))
+
+		log15.Info("Fetched", "File", r.URL[strings.LastIndex(r.URL, "/")+1:], "Count", len(ovalroot.Definitions.Definitions), "Timestamp", ovalroot.Generator.Timestamp)
+		ts, err := time.Parse("2006-01-02T15:04:05", ovalroot.Generator.Timestamp)
+		if err != nil {
+			return xerrors.Errorf("Failed to parse timestamp. url: %s, timestamp: %s, err: %w", r.URL, err, ovalroot.Generator.Timestamp)
+		}
+		if ts.Before(time.Now().AddDate(0, 0, -3)) {
+			log15.Warn("The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue.", "GitHub", "https://github.com/vulsio/goval-dictionary/issues", "OVAL", r.URL, "Timestamp", ovalroot.Generator.Timestamp)
+		}
 
 		root := models.Root{
 			Family:      c.Ubuntu,

--- a/fetcher/util.go
+++ b/fetcher/util.go
@@ -85,14 +85,12 @@ func fetchFeedFiles(reqs []fetchRequest) (results []FetchResult, err error) {
 		select {
 		case res := <-resChan:
 			results = append(results, res)
-			log15.Info("Fetched... ", "URL", res.URL)
 		case err := <-errChan:
 			errs = append(errs, err)
 		case <-timeout:
 			return results, fmt.Errorf("Timeout Fetching")
 		}
 	}
-	log15.Info("Finished fetching OVAL definitions")
 	if 0 < len(errs) {
 		return results, fmt.Errorf("%s", errs)
 	}


### PR DESCRIPTION
# What did you implement:

Changed to show Warn message if the file hasn't been updated for 3 days.
This will allow us to notice if the OVAL URL has been changed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Warn
```
INFO[01-29|08:16:04] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-buster.xml
INFO[01-29|08:16:09] Fetched                                  File=oval-definitions-buster.xml Count=23064 Timestamp=2022-01-28T19:31:40.188-04:00
WARN[01-29|08:16:09] The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue. GitHub=https://github.com/vulsio/goval-dictionary/issues OVAL=https://www.debian.org/security/oval/oval-definitions-buster.xml Timestamp=2022-01-28T19:31:40.188-04:00
INFO[01-29|08:16:09] Refreshing...                            Family=debian Version=10
```
- ubuntu
```
INFO[01-29|08:33:55] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.bionic.cve.oval.xml.bz2
INFO[01-29|08:34:01] Fetched                                  File=com.ubuntu.bionic.cve.oval.xml.bz2 Count=14648 Timestamp=2022-01-28T20:14:01
INFO[01-29|08:34:03] Refreshing...                            Family=ubuntu Version=18
```

- debian
```
INFO[01-29|08:15:42] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-buster.xml
INFO[01-29|08:15:47] Fetched                                  File=oval-definitions-buster.xml Count=23064 Timestamp=2022-01-28T19:31:40.188-04:00
INFO[01-29|08:15:47] Refreshing...                            Family=debian Version=10
```

- rhel
```
INFO[01-29|08:18:37] Fetching...                              URL=https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2
INFO[01-29|08:18:39] Fetched                                  File=com.redhat.rhsa-RHEL7.xml.bz2 Count=1356 Timestamp=2022-01-28T11:41:33
INFO[01-29|08:18:39] Refreshing...                            Family=redhat Version=7
```
- oracle
```
INFO[01-29|08:17:26] Fetching...                              URL=https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2
INFO[01-29|08:17:35] Fetched                                  File=com.oracle.elsa-all.xml.bz2 Count=4419 Timestamp=2022-01-28T03:29:45
INFO[01-29|08:17:36] Refreshing...                            Family=oracle Version=8
```

- suse
```
INFO[01-29|08:20:10] Fetching...                              URL=https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.15.xml
INFO[01-29|08:20:40] Fetched                                  File=suse.linux.enterprise.server.15.xml Count=10422 Timestamp=2022-01-28T05:24:10
```

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES