### PR TITLE
fix(rdb): misconfigured index in package

### DIFF
--- a/db/rdb.go
+++ b/db/rdb.go
@@ -305,7 +305,7 @@ func (r *RDBDriver) InsertOval(root *models.Root) error {
 		for _, d := range root.Definitions[idx.From:idx.To] {
 			for idx2 := range chunkSlice(len(d.AffectedPacks), batchSize) {
 				for i := range d.AffectedPacks[idx2.From:idx2.To] {
-					d.AffectedPacks[i].DefinitionID = d.ID
+					d.AffectedPacks[idx2.From+i].DefinitionID = d.ID
 				}
 				if err := tx.Create(d.AffectedPacks[idx2.From:idx2.To]).Error; err != nil {
 					tx.Rollback()


### PR DESCRIPTION
# What did you implement:

When inserting packages that exceed `--batch-size`, after the second round of loop, some packages failed to set their definition_id because they were not done for packages in the range `idx2.From + i`.
https://github.com/vulsio/goval-dictionary/blob/master/db/rdb.go#L307-L309

Therefore, when deleting, the DB space was increased because it was not possible to delete the Package that was supposed to be bound to the Definition. There is also a problem that data that should have been displayed when searching was not displayed.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## master
```console
$ goval-dictionary fetch amazon 2>/dev/null && ll oval.sqlite3
-rw-r--r-- 1 mainek00n mainek00n 9.2M Mar 14 12:15 oval.sqlite3
$ sqlite3 oval.sqlite3 "SELECT COUNT(definition_id) FROM packages WHERE definition_id = 0;"
17601

$ goval-dictionary fetch amazon 2>/dev/null && ll oval.sqlite3
-rw-r--r-- 1 mainek00n mainek00n 12M Mar 14 12:15 oval.sqlite3
```

## MaineK00n/fix-index-rdb
```console
$ goval-dictionary fetch amazon 2>/dev/null && ll oval.sqlite3
-rw-r--r-- 1 mainek00n mainek00n 9.3M Mar 14 12:26 oval.sqlite3
$ sqlite3 oval.sqlite3 "SELECT COUNT(definition_id) FROM packages WHERE definition_id = 0;"
0

$ goval-dictionary fetch amazon 2>/dev/null && ll oval.sqlite3
-rw-r--r-- 1 mainek00n mainek00n 9.4M Mar 14 12:27 oval.sqlite3
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

