### PR TITLE
fix(suse): not recognizing SUSE Manager as Package

### DIFF
--- a/fetcher/util/util_test.go
+++ b/fetcher/util/util_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -41,6 +42,7 @@ func TestCveIDPattern(t *testing.T) {
 func TestUniqueStrings(t *testing.T) {
 	in := []string{"1", "1", "2", "3", "1", "2"}
 	got := UniqueStrings(in)
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
 	want := []string{"1", "2", "3"}
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("(-got +want):\n%s", diff)

--- a/models/suse/suse.go
+++ b/models/suse/suse.go
@@ -239,7 +239,9 @@ func walkCriterion(cri Criteria, versions []string, packages []models.Package, t
 				log15.Warn("Failed to getOSVersion", "comment", comment, "err", err)
 				continue
 			}
-			versions = append(versions, v)
+			if v != "" {
+				versions = append(versions, v)
+			}
 			continue
 		}
 
@@ -280,7 +282,7 @@ func isOSComment(comment string) bool {
 		comment == "core9 is installed" ||
 		(strings.HasPrefix(comment, "sles10") && !strings.Contains(comment, "-docker-image-")) || // os: sles10-sp1 is installed, pkg: sles12-docker-image-1.1.4-20171002 is installed
 		strings.HasPrefix(comment, "sled10") || // os: sled10-sp1 is installed
-		strings.HasPrefix(comment, "openSUSE") || strings.HasPrefix(comment, "SUSE Linux Enterprise") {
+		strings.HasPrefix(comment, "openSUSE") || strings.HasPrefix(comment, "SUSE Linux Enterprise") || strings.HasPrefix(comment, "SUSE Manager") {
 		return true
 	}
 	return false
@@ -402,6 +404,11 @@ func getOSVersion(platformName string) (string, error) {
 			return "", xerrors.Errorf("Failed to detect os version. platformName: %s, err: %w", platformName, err)
 		}
 		return ver, nil
+	}
+
+	if strings.HasPrefix(platformName, "SUSE Manager") {
+		// e.g. SUSE Manager Proxy 4.0, SUSE Manager Server 4.0
+		return "", nil
 	}
 
 	return "", xerrors.Errorf("Failed to detect os version. platformName: %s, err: not support platform", platformName)

--- a/models/suse/suse.go
+++ b/models/suse/suse.go
@@ -384,6 +384,11 @@ func getOSVersion(platformName string) (string, error) {
 	}
 
 	if strings.HasPrefix(platformName, "SUSE Linux Enterprise") {
+		// e.g. SUSE Linux Enterprise Micro 5.1
+		if strings.HasPrefix(platformName, "SUSE Linux Enterprise Micro") {
+			return "", nil
+		}
+
 		// e.g. SUSE Linux Enterprise Server 12 SP1-LTSS
 		ss := strings.Fields(platformName)
 		if strings.HasPrefix(ss[len(ss)-1], "SP") || isInt(ss[len(ss)-2]) {

--- a/models/suse/suse.go
+++ b/models/suse/suse.go
@@ -384,8 +384,8 @@ func getOSVersion(platformName string) (string, error) {
 	}
 
 	if strings.HasPrefix(platformName, "SUSE Linux Enterprise") {
-		// e.g. SUSE Linux Enterprise Micro 5.1
-		if strings.HasPrefix(platformName, "SUSE Linux Enterprise Micro") {
+		// e.g. SUSE Linux Enterprise Storage 7, SUSE Linux Enterprise Micro 5.1
+		if strings.HasPrefix(platformName, "SUSE Linux Enterprise Storage") || strings.HasPrefix(platformName, "SUSE Linux Enterprise Micro") {
 			return "", nil
 		}
 

--- a/models/suse/suse_test.go
+++ b/models/suse/suse_test.go
@@ -338,6 +338,9 @@ func TestWalkSUSE(t *testing.T) {
 							{
 								Comment: "SUSE Linux Enterprise Micro 5.1 is installed",
 							},
+							{
+								Comment: "SUSE Linux Enterprise Storage 7 is installed",
+							},
 						},
 					},
 				},
@@ -523,6 +526,10 @@ func TestGetOSVersion(t *testing.T) {
 		},
 		{
 			s:        "SUSE Linux Enterprise Micro 5.1",
+			expected: "",
+		},
+		{
+			s:        "SUSE Linux Enterprise Storage 7",
 			expected: "",
 		},
 	}

--- a/models/suse/suse_test.go
+++ b/models/suse/suse_test.go
@@ -328,10 +328,20 @@ func TestWalkSUSE(t *testing.T) {
 		{
 			cri: Criteria{
 				Operator: "AND",
-				Criterions: []Criterion{
+				Criterias: []Criteria{
 					{
-						Comment: "SUSE Manager Proxy 4.0 is installed",
+						Operator: "OR",
+						Criterions: []Criterion{
+							{
+								Comment: "SUSE Manager Proxy 4.0 is installed",
+							},
+							{
+								Comment: "SUSE Linux Enterprise Micro 5.1 is installed",
+							},
+						},
 					},
+				},
+				Criterions: []Criterion{
 					{
 						TestRef: "oval:org.opensuse.security:tst:99999999999",
 						Comment: "mailx-12.5-1.87 is installed",
@@ -509,6 +519,10 @@ func TestGetOSVersion(t *testing.T) {
 		},
 		{
 			s:        "SUSE Manager Proxy 4.0",
+			expected: "",
+		},
+		{
+			s:        "SUSE Linux Enterprise Micro 5.1",
 			expected: "",
 		},
 	}

--- a/models/suse/suse_test.go
+++ b/models/suse/suse_test.go
@@ -327,7 +327,28 @@ func TestWalkSUSE(t *testing.T) {
 		},
 		{
 			cri: Criteria{
-				Operator: "OR",
+				Operator: "AND",
+				Criterions: []Criterion{
+					{
+						Comment: "SUSE Manager Proxy 4.0 is installed",
+					},
+					{
+						TestRef: "oval:org.opensuse.security:tst:99999999999",
+						Comment: "mailx-12.5-1.87 is installed",
+					},
+				},
+			},
+			tests: map[string]rpmInfoTest{
+				"oval:org.opensuse.security:tst:99999999999": {
+					Name:         "mailx",
+					FixedVersion: "0:12.5-1.87",
+				},
+			},
+			expected: []distroPackage{},
+		},
+		{
+			cri: Criteria{
+				Operator: "AND",
 				Criterions: []Criterion{
 					{
 						Comment: "SUSE Linux Enterprise Server 12 is installed",
@@ -485,6 +506,10 @@ func TestGetOSVersion(t *testing.T) {
 		{
 			s:        "SUSE Linux Enterprise Server for Python 2 15 SP1",
 			expected: "15.1",
+		},
+		{
+			s:        "SUSE Manager Proxy 4.0",
+			expected: "",
 		},
 	}
 


### PR DESCRIPTION
# What did you implement:

Recognize `SUSE Manager` as an OS, not as a Package, and do not Insert it into the DB.
Also, do not insert `SUSE Enterprise Micro`, `SUSE Enterprise Storage` that has been inserted as SUSE Enterprise Server (Desktop).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## master
```console
$ goval-dictionary fetch suse --suse-type suse-enterprise-server 15 2>/dev/null
$ sqlite3 oval.sqlite3 "SELECT COUNT(name) FROM packages WHERE name = 'SUSE-Manager-Proxy-release';"
188600
$ sqlite3 oval.sqlite3 "SELECT * FROM roots;"
1|suse.linux.enterprise.server|15.4|2022-03-14 13:53:17.804896628+09:00
2|suse.linux.enterprise.server|5.1|2022-03-14 13:53:17.937815186+09:00 // SUSE Enterprise Micro
3|suse.linux.enterprise.server|15.1|2022-03-14 13:53:18.044831984+09:00
4|suse.linux.enterprise.server|15.2|2022-03-14 13:53:23.651155612+09:00
5|suse.linux.enterprise.server|6|2022-03-14 13:53:29.809966153+09:00 // SUSE Enterprise Storage
6|suse.linux.enterprise.server|7|2022-03-14 13:53:31.945193689+09:00 // SUSE Enterprise Storage
7|suse.linux.enterprise.server|15|2022-03-14 13:53:34.491346722+09:00
8|suse.linux.enterprise.server|15.3|2022-03-14 13:53:39.310429785+09:00
```

## MaineK00n/ignore-SUSE-Manager
```console
$ goval-dictionary fetch suse --suse-type suse-enterprise-server 15 2>/dev/null
$ sqlite3 oval.sqlite3 "SELECT COUNT(name) FROM packages WHERE name = 'SUSE-Manager-Proxy-release';"
0
$ sqlite3 oval.sqlite3 "SELECT * FROM roots;"
1|suse.linux.enterprise.server|15.1|2022-03-14 13:56:30.728035101+09:00
2|suse.linux.enterprise.server|15.2|2022-03-14 13:56:34.784837112+09:00
3|suse.linux.enterprise.server|15.3|2022-03-14 13:56:38.988323516+09:00
4|suse.linux.enterprise.server|15.4|2022-03-14 13:56:43.731540722+09:00
5|suse.linux.enterprise.server|15|2022-03-14 13:56:43.807080189+09:00
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

