### PR TITLE
feat(ubuntu): add Jammy Jellyfish(22.04)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -96,7 +96,7 @@ clean-integration:
 
 fetch-rdb:
 	integration/goval-dict.old fetch debian --dbpath=$(PWD)/integration/oval.old.sqlite3 7 8 9 10 11
-	integration/goval-dict.old fetch ubuntu --dbpath=$(PWD)/integration/oval.old.sqlite3 14 16 18 19 20
+	integration/goval-dict.old fetch ubuntu --dbpath=$(PWD)/integration/oval.old.sqlite3 14 16 18 19 20 21 22
 	integration/goval-dict.old fetch redhat --dbpath=$(PWD)/integration/oval.old.sqlite3 5 6 7 8
 	integration/goval-dict.old fetch oracle --dbpath=$(PWD)/integration/oval.old.sqlite3
 	integration/goval-dict.old fetch amazon --dbpath=$(PWD)/integration/oval.old.sqlite3
@@ -108,7 +108,7 @@ fetch-rdb:
 	integration/goval-dict.old fetch fedora --dbpath=$(PWD)/integration/oval.old.sqlite3 32 33 34 35
 
 	integration/goval-dict.new fetch debian --dbpath=$(PWD)/integration/oval.new.sqlite3 7 8 9 10 11
-	integration/goval-dict.new fetch ubuntu --dbpath=$(PWD)/integration/oval.new.sqlite3 14 16 18 19 20
+	integration/goval-dict.new fetch ubuntu --dbpath=$(PWD)/integration/oval.new.sqlite3 14 16 18 19 20 21 22
 	integration/goval-dict.new fetch redhat --dbpath=$(PWD)/integration/oval.new.sqlite3 5 6 7 8
 	integration/goval-dict.new fetch oracle --dbpath=$(PWD)/integration/oval.new.sqlite3
 	integration/goval-dict.new fetch amazon --dbpath=$(PWD)/integration/oval.new.sqlite3
@@ -124,7 +124,7 @@ fetch-redis:
 	docker run --name redis-new -d -p 127.0.0.1:6380:6379 redis
 
 	integration/goval-dict.old fetch debian --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 7 8 9 10 11
-	integration/goval-dict.old fetch ubuntu --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 14 16 18 19 20
+	integration/goval-dict.old fetch ubuntu --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 14 16 18 19 20 21 22
 	integration/goval-dict.old fetch redhat --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 5 6 7 8
 	integration/goval-dict.old fetch oracle --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
 	integration/goval-dict.old fetch amazon --dbtype redis --dbpath "redis://127.0.0.1:6379/0"
@@ -136,7 +136,7 @@ fetch-redis:
 	integration/goval-dict.old fetch fedora --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 32 33 34 35
 
 	integration/goval-dict.new fetch debian --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 7 8 9 10 11
-	integration/goval-dict.new fetch ubuntu --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 14 16 18 19 20
+	integration/goval-dict.new fetch ubuntu --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 14 16 18 19 20 21 22
 	integration/goval-dict.new fetch redhat --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 5 6 7 8
 	integration/goval-dict.new fetch oracle --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
 	integration/goval-dict.new fetch amazon --dbtype redis --dbpath "redis://127.0.0.1:6380/0"
@@ -149,7 +149,7 @@ fetch-redis:
 
 diff-cveid:
 	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid debian 7 8 9 10 11
-	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid ubuntu 14 16 18 19 20
+	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid ubuntu 14 16 18 19 20 21 22
 	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid redhat 5 6 7 8
 	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid oracle 5 6 7 8
 	@ python integration/diff_server_mode.py --sample-rate 0.01 --arch x86_64 cveid oracle 5 6 7 8
@@ -166,7 +166,7 @@ diff-cveid:
 
 diff-package:
 	@ python integration/diff_server_mode.py --sample-rate 0.01 package debian 7 8 9 10 11
-	@ python integration/diff_server_mode.py --sample-rate 0.01 package ubuntu 14 16 18 19 20
+	@ python integration/diff_server_mode.py --sample-rate 0.01 package ubuntu 14 16 18 19 20 21 22
 	@ python integration/diff_server_mode.py --sample-rate 0.01 package redhat 5 6 7 8
 	@ python integration/diff_server_mode.py --sample-rate 0.01 package oracle 5 6 7 8
 	@ python integration/diff_server_mode.py --sample-rate 0.01 --arch x86_64 package oracle 5 6 7 8

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ $ goval-dictionary fetch debian 7 8 9 10 11
 - [Ubuntu(sub)](https://people.canonical.com/~ubuntu-security/oval/)
 
 ```bash
-$ goval-dictionary fetch ubuntu 14 16 18 19 20 21
+$ goval-dictionary fetch ubuntu 14 16 18 19 20 21 22
 ```
 
 #### Usage: Fetch OVAL data from SUSE

--- a/config/config.go
+++ b/config/config.go
@@ -22,13 +22,13 @@ const (
 	// Raspbian is
 	Raspbian = "raspbian"
 
-	// Ubuntu14 is Ubuntu Trusty
+	// Ubuntu14 is Trusty Tahr
 	Ubuntu14 = "trusty"
 
-	// Ubuntu16 is Ubuntu Xenial
+	// Ubuntu16 is Xenial Xerus
 	Ubuntu16 = "xenial"
 
-	// Ubuntu18 is Ubuntu Bionic
+	// Ubuntu18 is Bionic Beaver
 	Ubuntu18 = "bionic"
 
 	// Ubuntu19 is Eoan Ermine
@@ -39,6 +39,9 @@ const (
 
 	// Ubuntu21 is Hirsute Hippo
 	Ubuntu21 = "hirsute"
+
+	// Ubuntu22 is Jammy Jellyfish
+	Ubuntu22 = "jammy"
 
 	// Debian7 is wheezy
 	Debian7 = "wheezy"

--- a/fetcher/ubuntu/ubuntu.go
+++ b/fetcher/ubuntu/ubuntu.go
@@ -51,6 +51,8 @@ func getOVALURL(major string) string {
 		return fmt.Sprintf(main, config.Ubuntu20)
 	case "21":
 		return fmt.Sprintf(main, config.Ubuntu21)
+	case "22":
+		return fmt.Sprintf(main, config.Ubuntu22)
 	default:
 		return "unknown"
 	}

--- a/integration/diff_server_mode.py
+++ b/integration/diff_server_mode.py
@@ -126,7 +126,7 @@ if args.ostype == 'debian':
             f'Failed to diff_response..., err: This Release Version({args.release}) does not support test mode')
         raise NotImplementedError
 elif args.ostype == 'ubuntu':
-    if len(list(set(args.release) - set(['14', '16', '18', '19', '20']))) > 0:
+    if len(list(set(args.release) - set(['14', '16', '18', '19', '20', '21', '22']))) > 0:
         logger.error(
             f'Failed to diff_response..., err: This Release Version({args.release}) does not support test mode')
         raise NotImplementedError


### PR DESCRIPTION
# What did you implement:

Ubuntu 22.04 will be released on April 21.
OVAL is also available for 22.04, which can be fetched.
OVAL URL: https://security-metadata.canonical.com/oval/com.ubuntu.jammy.cve.oval.xml.bz2

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ goval-dictionary fetch ubuntu 22
INFO[04-25|11:38:19] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.jammy.cve.oval.xml.bz2
INFO[04-25|11:38:20] Fetched                                  File=com.ubuntu.jammy.cve.oval.xml.bz2 Count=1 Timestamp=2022-04-25T01:47:04
INFO[04-25|11:38:20] Refreshing...                            Family=ubuntu Version=22
INFO[04-25|11:38:20] Inserting new Definitions... 
1 / 1 [----------------------------------------------------------] 100.00% ? p/s
INFO[04-25|11:38:20] Finish                                   Updated=1

$ sqlite3 oval.sqlite3 "SELECT * FROM roots;"
1|ubuntu|22|2022-04-25 11:38:20.271652506+09:00
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
