### PR TITLE
chore: fix lint error

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.42
+          version: v1.45
           args: --timeout=10m
           
           # Optional: working directory, useful for monorepos

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,7 +19,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.x
+        go-version: 1.18.x
       id: go
 
     - name: Check out code into the Go module directory

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,9 @@
 name: golang-ci
 
+run:
+  timeout: 10m
+  go: '1.18'
+
 linters-settings:
   revive:
     # see https://github.com/mgechev/revive#available-rules for details.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . $GOPATH/src/$REPOSITORY
 RUN cd $GOPATH/src/$REPOSITORY && make install
 
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 LABEL maintainer sadayuki-matsuno
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,6 +3,7 @@
 	build \
 	install \
 	lint \
+	golangci \
 	vet \
 	fmt \
 	mlint \
@@ -43,8 +44,12 @@ install: main.go
 	$(GO) install -ldflags "$(LDFLAGS)"
 
 lint:
-	$(GO_OFF) get -u github.com/mgechev/revive
+	$(GO) install github.com/mgechev/revive@latest
 	revive -config ./.revive.toml -formatter plain $(PKGS)
+
+golangci:
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	golangci-lint run
 
 vet:
 	echo $(PKGS) | xargs env $(GO) vet || exit;

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -12,8 +12,6 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/mattn/go-sqlite3"
 	"github.com/spf13/viper"
-	c "github.com/vulsio/goval-dictionary/config"
-	"github.com/vulsio/goval-dictionary/models"
 	"golang.org/x/xerrors"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
@@ -21,6 +19,9 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/logger"
+
+	c "github.com/vulsio/goval-dictionary/config"
+	"github.com/vulsio/goval-dictionary/models"
 )
 
 // Supported DB dialects.

--- a/db/redis.go
+++ b/db/redis.go
@@ -12,9 +12,10 @@ import (
 	"github.com/go-redis/redis/v8"
 	"github.com/inconshreveable/log15"
 	"github.com/spf13/viper"
+	"golang.org/x/xerrors"
+
 	c "github.com/vulsio/goval-dictionary/config"
 	"github.com/vulsio/goval-dictionary/models"
-	"golang.org/x/xerrors"
 )
 
 /**

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vulsio/goval-dictionary
 
-go 1.17
+go 1.18
 
 require (
 	github.com/cheggaaa/pb/v3 v3.0.8

--- a/go.sum
+++ b/go.sum
@@ -264,7 +264,6 @@ github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac/go.mod h1:cO
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -283,7 +282,6 @@ github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2 h1:JVX6jT/XfzNqIjye47
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
-github.com/jackc/pgproto3 v1.1.0 h1:FYYE4yRw+AgI8wXIinMlNjBbp/UitDJwfj5LqqewP1A=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod h1:uH0AWtUmuShn0bcesswc4aBTWGvw0cAxIJp+6OB//Wg=

--- a/models/alpine/alpine.go
+++ b/models/alpine/alpine.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+
 	"github.com/vulsio/goval-dictionary/models"
 )
 

--- a/models/suse/suse_test.go
+++ b/models/suse/suse_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/k0kubun/pp"
+
 	"github.com/vulsio/goval-dictionary/models"
 )
 

--- a/server/server.go
+++ b/server/server.go
@@ -12,8 +12,9 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/spf13/viper"
-	"github.com/vulsio/goval-dictionary/db"
 	"golang.org/x/xerrors"
+
+	"github.com/vulsio/goval-dictionary/db"
 )
 
 // Start starts CVE dictionary HTTP Server.


### PR DESCRIPTION
# What did you implement:

fix lint errors.

## Type of change

# How Has This Been Tested?
```console
$ golangci-lint version
golangci-lint has version v1.45.2 built from (unknown, mod sum: "h1:9I3PzkvscJkFAQpTQi5Ga0V4qWdJERajX1UZ7QqkW+I=") on (unknown)
$ golangci-lint run -c .golangci.yml
WARN [linters context] staticcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
$ make test
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

