### PR TITLE
feat: support multi layout

### DIFF
--- a/models/amazon/amazon.go
+++ b/models/amazon/amazon.go
@@ -44,8 +44,8 @@ func ConvertToModel(data *Updates) (defs []models.Definition) {
 			})
 		}
 
-		issuedAt := util.ParsedOrDefaultTime("2006-01-02 15:04", alas.Issued.Date)
-		updatedAt := util.ParsedOrDefaultTime("2006-01-02 15:04", alas.Updated.Date)
+		issuedAt := util.ParsedOrDefaultTime([]string{"2006-01-02 15:04"}, alas.Issued.Date)
+		updatedAt := util.ParsedOrDefaultTime([]string{"2006-01-02 15:04"}, alas.Updated.Date)
 
 		def := models.Definition{
 			DefinitionID: "def-" + alas.ID,

--- a/models/debian/debian.go
+++ b/models/debian/debian.go
@@ -53,7 +53,7 @@ func ConvertToModel(root *Root) (defs []models.Definition) {
 			},
 			Debian: &models.Debian{
 				MoreInfo: ovaldef.Debian.MoreInfo,
-				Date:     util.ParsedOrDefaultTime("2006-01-02", ovaldef.Debian.Date),
+				Date:     util.ParsedOrDefaultTime([]string{"2006-01-02"}, ovaldef.Debian.Date),
 			},
 			AffectedPacks: collectDebianPacks(ovaldef.Criteria),
 			References:    rs,

--- a/models/fedora/fedora.go
+++ b/models/fedora/fedora.go
@@ -53,8 +53,8 @@ func ConvertToModel(data *Updates) (defs []models.Definition) {
 			}
 		}
 
-		issuedAt := util.ParsedOrDefaultTime("2006-01-02 15:04:05", update.Issued.Date)
-		updatedAt := util.ParsedOrDefaultTime("2006-01-02 15:04:05", update.Updated.Date)
+		issuedAt := util.ParsedOrDefaultTime([]string{"2006-01-02 15:04:05"}, update.Issued.Date)
+		updatedAt := util.ParsedOrDefaultTime([]string{"2006-01-02 15:04:05"}, update.Updated.Date)
 		def := models.Definition{
 			DefinitionID: "def-" + update.ID,
 			Title:        update.ID,

--- a/models/redhat/redhat.go
+++ b/models/redhat/redhat.go
@@ -55,9 +55,8 @@ func ConvertToModel(root *Root) (defs []models.Definition) {
 			})
 		}
 
-		const timeformat = "2006-01-02"
-		issued := util.ParsedOrDefaultTime(timeformat, d.Advisory.Issued.Date)
-		updated := util.ParsedOrDefaultTime(timeformat, d.Advisory.Updated.Date)
+		issued := util.ParsedOrDefaultTime([]string{"2006-01-02"}, d.Advisory.Issued.Date)
+		updated := util.ParsedOrDefaultTime([]string{"2006-01-02"}, d.Advisory.Updated.Date)
 
 		def := models.Definition{
 			DefinitionID: d.ID,

--- a/models/ubuntu/ubuntu.go
+++ b/models/ubuntu/ubuntu.go
@@ -49,12 +49,7 @@ func ConvertToModel(root *Root) (defs []models.Definition) {
 			})
 		}
 
-		var date time.Time
-		if strings.HasSuffix(d.Advisory.PublicDate, "UTC") {
-			date = util.ParsedOrDefaultTime("2006-01-02 15:04:05 UTC", d.Advisory.PublicDate)
-		} else {
-			date = util.ParsedOrDefaultTime("2006-01-02", d.Advisory.PublicDate)
-		}
+		date := util.ParsedOrDefaultTime([]string{"2006-01-02", "2006-01-02 15:04:05", "2006-01-02 15:04:05 +0000", "2006-01-02 15:04:05 UTC"}, d.Advisory.PublicDate)
 
 		def := models.Definition{
 			DefinitionID: d.ID,

--- a/models/util/util.go
+++ b/models/util/util.go
@@ -7,15 +7,17 @@ import (
 )
 
 // ParsedOrDefaultTime returns time.Parse(layout, value), or time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC) if it failed to parse
-func ParsedOrDefaultTime(layout, value string) time.Time {
+func ParsedOrDefaultTime(layouts []string, value string) time.Time {
 	defaultTime := time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)
-	if value == "" {
+	if value == "" || value == "unknown" {
 		return defaultTime
 	}
-	t, err := time.Parse(layout, value)
-	if err != nil {
-		log15.Warn("Failed to parse string", "timeformat", layout, "target string", value, "err", err)
-		return defaultTime
+
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t
+		}
 	}
-	return t
+	log15.Warn("Failed to parse string", "timeformat", layouts, "target string", value)
+	return defaultTime
 }

--- a/models/util/util_test.go
+++ b/models/util/util_test.go
@@ -7,28 +7,45 @@ import (
 
 func TestParsedOrDefaultTime(t *testing.T) {
 	tests := []struct {
-		name   string
-		in     string
-		layout string
-		want   time.Time
+		name    string
+		in      string
+		layouts []string
+		want    time.Time
 	}{
 		{
-			name:   "success to parse",
-			in:     "2021-01-02",
-			layout: "2006-01-02",
-			want:   time.Date(2021, time.January, 2, 0, 0, 0, 0, time.UTC),
+			name:    "success to parse",
+			in:      "2021-01-02",
+			layouts: []string{"2006-01-02"},
+			want:    time.Date(2021, time.January, 2, 0, 0, 0, 0, time.UTC),
 		},
 		{
-			name:   "failed to parse",
-			in:     "2021/01/02",
-			layout: "2006-01-02",
-			want:   time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			name:    "success to parse(multi layout)",
+			in:      "2021-01-02 15:00:00",
+			layouts: []string{"2006-01-02", "2006-01-02 15:04:05"},
+			want:    time.Date(2021, time.January, 2, 15, 0, 0, 0, time.UTC),
+		},
+		{
+			name:    "failed to parse",
+			in:      "2021/01/02",
+			layouts: []string{"2006-01-02"},
+			want:    time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:    "empty string",
+			in:      "",
+			layouts: []string{"2006-01-02"},
+			want:    time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:    "unknown",
+			in:      "unknown",
+			layouts: []string{"2006-01-02"},
+			want:    time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ParsedOrDefaultTime(tt.layout, tt.in)
-			if got != tt.want {
+			if got := ParsedOrDefaultTime(tt.layouts, tt.in); got != tt.want {
 				t.Errorf("got: %v, want: %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
# What did you implement:

Multiple layouts are accepted when parsing time.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## before
```console
$ goval-dictionary fetch ubuntu 14 16 18 19 20 21 22
INFO[05-10|13:16:00] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.bionic.cve.oval.xml.bz2
INFO[05-10|13:16:00] Fetching...                              URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.eoan.cve.oval.xml.bz2
INFO[05-10|13:16:00] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.focal.cve.oval.xml.bz2
INFO[05-10|13:16:00] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.hirsute.cve.oval.xml.bz2
INFO[05-10|13:16:00] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.jammy.cve.oval.xml.bz2
INFO[05-10|13:16:00] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.trusty.cve.oval.xml.bz2
INFO[05-10|13:16:00] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.xenial.cve.oval.xml.bz2
INFO[05-10|13:16:06] Fetched                                  File=com.ubuntu.hirsute.cve.oval.xml.bz2 Count=8226 Timestamp=2022-01-11T10:07:17
WARN[05-10|13:16:06] The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue. GitHub=https://github.com/vulsio/goval-dictionary/issues OVAL=https://security-metadata.canonical.com/oval/com.ubuntu.hirsute.cve.oval.xml.bz2 Timestamp=2022-01-11T10:07:17
WARN[05-10|13:16:07] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:07] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:07] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:07] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:07] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:07] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
INFO[05-10|13:16:07] Refreshing...                            Family=ubuntu Version=21
INFO[05-10|13:16:07] Inserting new Definitions... 
8226 / 8226 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 19181 p/s
INFO[05-10|13:16:07] Finish                                   Updated=8226
INFO[05-10|13:16:08] Fetched                                  File=com.ubuntu.jammy.cve.oval.xml.bz2 Count=8930 Timestamp=2022-05-10T03:56:34
WARN[05-10|13:16:08] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:08] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:08] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:08] Failed to parse string                   timeformat=2006-01-02 target string=unknown err="parsing time \"unknown\" as \"2006-01-02\": cannot parse \"unknown\" as \"2006\""
WARN[05-10|13:16:08] Failed to parse string                   timeformat=2006-01-02 target string=unknown err="parsing time \"unknown\" as \"2006-01-02\": cannot parse \"unknown\" as \"2006\""
WARN[05-10|13:16:08] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:08] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:08] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:09] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
WARN[05-10|13:16:09] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
WARN[05-10|13:16:09] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
INFO[05-10|13:16:09] Refreshing...                            Family=ubuntu Version=22
INFO[05-10|13:16:09] Inserting new Definitions... 
8930 / 8930 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 16450 p/s
INFO[05-10|13:16:09] Finish                                   Updated=8930
INFO[05-10|13:16:10] Fetched                                  File=com.ubuntu.eoan.cve.oval.xml.bz2 Count=6393 Timestamp=2020-07-17T14:48:25
WARN[05-10|13:16:10] The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue. GitHub=https://github.com/vulsio/goval-dictionary/issues OVAL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.eoan.cve.oval.xml.bz2 Timestamp=2020-07-17T14:48:25
WARN[05-10|13:16:10] Failed to parse string                   timeformat=2006-01-02 target string="2020-07-15 12:00:00" err="parsing time \"2020-07-15 12:00:00\": extra text: \" 12:00:00\""
INFO[05-10|13:16:10] Refreshing...                            Family=ubuntu Version=19
INFO[05-10|13:16:10] Inserting new Definitions... 
6385 / 6385 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 24829 p/s
INFO[05-10|13:16:11] Finish                                   Updated=6385
INFO[05-10|13:16:12] Fetched                                  File=com.ubuntu.focal.cve.oval.xml.bz2 Count=10338 Timestamp=2022-05-10T03:56:35
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string=unknown err="parsing time \"unknown\" as \"2006-01-02\": cannot parse \"unknown\" as \"2006\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string=unknown err="parsing time \"unknown\" as \"2006-01-02\": cannot parse \"unknown\" as \"2006\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2020-07-15 12:00:00" err="parsing time \"2020-07-15 12:00:00\": extra text: \" 12:00:00\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2020-09-28 15:00:00" err="parsing time \"2020-09-28 15:00:00\": extra text: \" 15:00:00\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2020-09-28 15:00:00" err="parsing time \"2020-09-28 15:00:00\": extra text: \" 15:00:00\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2020-09-28 15:00:00" err="parsing time \"2020-09-28 15:00:00\": extra text: \" 15:00:00\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2020-09-28 15:00:00" err="parsing time \"2020-09-28 15:00:00\": extra text: \" 15:00:00\""
WARN[05-10|13:16:12] Failed to parse string                   timeformat=2006-01-02 target string="2020-09-28 15:00:00" err="parsing time \"2020-09-28 15:00:00\": extra text: \" 15:00:00\""
INFO[05-10|13:16:12] Refreshing...                            Family=ubuntu Version=20
INFO[05-10|13:16:12] Inserting new Definitions... 
10336 / 10336 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 14750 p/s
INFO[05-10|13:16:13] Finish                                   Updated=10336
INFO[05-10|13:16:15] Fetched                                  File=com.ubuntu.bionic.cve.oval.xml.bz2 Count=15549 Timestamp=2022-05-10T02:54:55
WARN[05-10|13:16:15] Failed to parse string                   timeformat=2006-01-02 target string="2016-07-18 14:00:00" err="parsing time \"2016-07-18 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:15] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:15] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:15] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:15] Failed to parse string                   timeformat=2006-01-02 target string=unknown err="parsing time \"unknown\" as \"2006-01-02\": cannot parse \"unknown\" as \"2006\""
WARN[05-10|13:16:15] Failed to parse string                   timeformat=2006-01-02 target string=unknown err="parsing time \"unknown\" as \"2006-01-02\": cannot parse \"unknown\" as \"2006\""
WARN[05-10|13:16:15] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:15] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:15] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:15] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
WARN[05-10|13:16:15] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
WARN[05-10|13:16:15] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
WARN[05-10|13:16:16] Failed to parse string                   timeformat=2006-01-02 target string="2018-04-23 00:00:00 +0000" err="parsing time \"2018-04-23 00:00:00 +0000\": extra text: \" 00:00:00 +0000\""
WARN[05-10|13:16:16] Failed to parse string                   timeformat=2006-01-02 target string="2018-07-10 17:00:00" err="parsing time \"2018-07-10 17:00:00\": extra text: \" 17:00:00\""
WARN[05-10|13:16:16] Failed to parse string                   timeformat=2006-01-02 target string="2020-07-15 12:00:00" err="parsing time \"2020-07-15 12:00:00\": extra text: \" 12:00:00\""
WARN[05-10|13:16:16] Failed to parse string                   timeformat=2006-01-02 target string="2020-12-03 18:16:00" err="parsing time \"2020-12-03 18:16:00\": extra text: \" 18:16:00\""
INFO[05-10|13:16:16] Refreshing...                            Family=ubuntu Version=18
INFO[05-10|13:16:16] Inserting new Definitions... 
15530 / 15530 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 13798 p/s
INFO[05-10|13:16:17] Finish                                   Updated=15530
INFO[05-10|13:16:19] Fetched                                  File=com.ubuntu.xenial.cve.oval.xml.bz2 Count=20806 Timestamp=2022-05-10T02:54:57
WARN[05-10|13:16:19] Failed to parse string                   timeformat=2006-01-02 target string="2016-07-18 14:00:00" err="parsing time \"2016-07-18 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:19] Failed to parse string                   timeformat=2006-01-02 target string="2016-07-18 14:00:00" err="parsing time \"2016-07-18 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:19] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:19] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:19] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:19] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:19] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:19] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:19] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
WARN[05-10|13:16:19] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2015-09-29 14:00:00" err="parsing time \"2015-09-29 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2015-09-22 15:00:00" err="parsing time \"2015-09-22 15:00:00\": extra text: \" 15:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2015-11-16 12:00:00" err="parsing time \"2015-11-16 12:00:00\": extra text: \" 12:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2016-02-23 15:00:00" err="parsing time \"2016-02-23 15:00:00\": extra text: \" 15:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2016-07-18 14:00:00" err="parsing time \"2016-07-18 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2016-07-18 14:00:00" err="parsing time \"2016-07-18 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2016-09-26 18:00:00" err="parsing time \"2016-09-26 18:00:00\": extra text: \" 18:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2016-11-23 16:00:00" err="parsing time \"2016-11-23 16:00:00\": extra text: \" 16:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2017-02-01 14:00:00" err="parsing time \"2017-02-01 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2017-10-26 15:00:00" err="parsing time \"2017-10-26 15:00:00\": extra text: \" 15:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2017-10-26 15:00:00" err="parsing time \"2017-10-26 15:00:00\": extra text: \" 15:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2017-11-15 19:00:00" err="parsing time \"2017-11-15 19:00:00\": extra text: \" 19:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2017-11-15 19:00:00" err="parsing time \"2017-11-15 19:00:00\": extra text: \" 19:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2017-03-09 16:00:00" err="parsing time \"2017-03-09 16:00:00\": extra text: \" 16:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2017-04-04 14:00:00" err="parsing time \"2017-04-04 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2017-04-04 14:00:00" err="parsing time \"2017-04-04 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2018-04-23 00:00:00 +0000" err="parsing time \"2018-04-23 00:00:00 +0000\": extra text: \" 00:00:00 +0000\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2018-07-10 17:00:00" err="parsing time \"2018-07-10 17:00:00\": extra text: \" 17:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2020-07-15 12:00:00" err="parsing time \"2020-07-15 12:00:00\": extra text: \" 12:00:00\""
WARN[05-10|13:16:20] Failed to parse string                   timeformat=2006-01-02 target string="2020-12-03 18:16:00" err="parsing time \"2020-12-03 18:16:00\": extra text: \" 18:16:00\""
INFO[05-10|13:16:20] Refreshing...                            Family=ubuntu Version=16
INFO[05-10|13:16:20] Inserting new Definitions... 
20765 / 20765 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 14722 p/s
INFO[05-10|13:16:22] Finish                                   Updated=20765
INFO[05-10|13:16:24] Fetched                                  File=com.ubuntu.trusty.cve.oval.xml.bz2 Count=22933 Timestamp=2022-05-10T02:55:02
WARN[05-10|13:16:24] Failed to parse string                   timeformat=2006-01-02 target string="2016-07-18 14:00:00" err="parsing time \"2016-07-18 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:24] Failed to parse string                   timeformat=2006-01-02 target string="2016-07-18 14:00:00" err="parsing time \"2016-07-18 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:24] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:24] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:24] Failed to parse string                   timeformat=2006-01-02 target string="2021-07-20 16:00:00 +0000" err="parsing time \"2021-07-20 16:00:00 +0000\": extra text: \" 16:00:00 +0000\""
WARN[05-10|13:16:24] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:24] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:24] Failed to parse string                   timeformat=2006-01-02 target string="2021-05-11 17:00:00 +0000" err="parsing time \"2021-05-11 17:00:00 +0000\": extra text: \" 17:00:00 +0000\""
WARN[05-10|13:16:24] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
WARN[05-10|13:16:24] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
WARN[05-10|13:16:24] Failed to parse string                   timeformat=2006-01-02 target string="2022-03-08 18:00:00 +0000" err="parsing time \"2022-03-08 18:00:00 +0000\": extra text: \" 18:00:00 +0000\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2015-11-26 18:00:00" err="parsing time \"2015-11-26 18:00:00\": extra text: \" 18:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2015-09-29 14:00:00" err="parsing time \"2015-09-29 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2015-11-03 18:00:00" err="parsing time \"2015-11-03 18:00:00\": extra text: \" 18:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2015-11-03 18:00:00" err="parsing time \"2015-11-03 18:00:00\": extra text: \" 18:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2015-11-03 18:00:00" err="parsing time \"2015-11-03 18:00:00\": extra text: \" 18:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2015-11-03 18:00:00" err="parsing time \"2015-11-03 18:00:00\": extra text: \" 18:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2015-09-22 15:00:00" err="parsing time \"2015-09-22 15:00:00\": extra text: \" 15:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2015-11-16 12:00:00" err="parsing time \"2015-11-16 12:00:00\": extra text: \" 12:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2015-11-24 17:00:00" err="parsing time \"2015-11-24 17:00:00\": extra text: \" 17:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2016-01-19 20:00:00" err="parsing time \"2016-01-19 20:00:00\": extra text: \" 20:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2016-02-23 15:00:00" err="parsing time \"2016-02-23 15:00:00\": extra text: \" 15:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2016-01-20 15:00:00" err="parsing time \"2016-01-20 15:00:00\": extra text: \" 15:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2016-07-18 14:00:00" err="parsing time \"2016-07-18 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2016-07-18 14:00:00" err="parsing time \"2016-07-18 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2016-09-26 18:00:00" err="parsing time \"2016-09-26 18:00:00\": extra text: \" 18:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2016-11-23 16:00:00" err="parsing time \"2016-11-23 16:00:00\": extra text: \" 16:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2017-10-26 15:00:00" err="parsing time \"2017-10-26 15:00:00\": extra text: \" 15:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2017-10-26 15:00:00" err="parsing time \"2017-10-26 15:00:00\": extra text: \" 15:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2017-11-15 19:00:00" err="parsing time \"2017-11-15 19:00:00\": extra text: \" 19:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2017-11-15 19:00:00" err="parsing time \"2017-11-15 19:00:00\": extra text: \" 19:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2017-11-15 19:00:00" err="parsing time \"2017-11-15 19:00:00\": extra text: \" 19:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2017-03-09 16:00:00" err="parsing time \"2017-03-09 16:00:00\": extra text: \" 16:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2017-04-04 14:00:00" err="parsing time \"2017-04-04 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2017-04-04 14:00:00" err="parsing time \"2017-04-04 14:00:00\": extra text: \" 14:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2018-04-23 00:00:00 +0000" err="parsing time \"2018-04-23 00:00:00 +0000\": extra text: \" 00:00:00 +0000\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2018-07-10 17:00:00" err="parsing time \"2018-07-10 17:00:00\": extra text: \" 17:00:00\""
WARN[05-10|13:16:25] Failed to parse string                   timeformat=2006-01-02 target string="2020-07-15 12:00:00" err="parsing time \"2020-07-15 12:00:00\": extra text: \" 12:00:00\""
INFO[05-10|13:16:25] Refreshing...                            Family=ubuntu Version=14
INFO[05-10|13:16:25] Inserting new Definitions... 
22855 / 22855 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 16988 p/s
INFO[05-10|13:16:27] Finish                                   Updated=22855
```

## after
```console
$ goval-dictionary fetch ubuntu 14 16 18 19 20 21 22
INFO[05-10|13:15:08] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.trusty.cve.oval.xml.bz2
INFO[05-10|13:15:08] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.xenial.cve.oval.xml.bz2
INFO[05-10|13:15:08] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.bionic.cve.oval.xml.bz2
INFO[05-10|13:15:08] Fetching...                              URL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.eoan.cve.oval.xml.bz2
INFO[05-10|13:15:08] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.focal.cve.oval.xml.bz2
INFO[05-10|13:15:08] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.hirsute.cve.oval.xml.bz2
INFO[05-10|13:15:08] Fetching...                              URL=https://security-metadata.canonical.com/oval/com.ubuntu.jammy.cve.oval.xml.bz2
INFO[05-10|13:15:15] Fetched                                  File=com.ubuntu.eoan.cve.oval.xml.bz2 Count=6393 Timestamp=2020-07-17T14:48:25
WARN[05-10|13:15:15] The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue. GitHub=https://github.com/vulsio/goval-dictionary/issues OVAL=https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.eoan.cve.oval.xml.bz2 Timestamp=2020-07-17T14:48:25
INFO[05-10|13:15:16] Refreshing...                            Family=ubuntu Version=19
INFO[05-10|13:15:16] Inserting new Definitions... 
6385 / 6385 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 22177 p/s
INFO[05-10|13:15:16] Finish                                   Updated=6385
INFO[05-10|13:15:17] Fetched                                  File=com.ubuntu.hirsute.cve.oval.xml.bz2 Count=8226 Timestamp=2022-01-11T10:07:17
WARN[05-10|13:15:17] The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue. GitHub=https://github.com/vulsio/goval-dictionary/issues OVAL=https://security-metadata.canonical.com/oval/com.ubuntu.hirsute.cve.oval.xml.bz2 Timestamp=2022-01-11T10:07:17
INFO[05-10|13:15:17] Refreshing...                            Family=ubuntu Version=21
INFO[05-10|13:15:17] Inserting new Definitions... 
8226 / 8226 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 25647 p/s
INFO[05-10|13:15:18] Finish                                   Updated=8226
INFO[05-10|13:15:18] Fetched                                  File=com.ubuntu.jammy.cve.oval.xml.bz2 Count=8926 Timestamp=2022-05-10T02:54:58
INFO[05-10|13:15:19] Refreshing...                            Family=ubuntu Version=22
INFO[05-10|13:15:19] Inserting new Definitions... 
8926 / 8926 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 20655 p/s
INFO[05-10|13:15:19] Finish                                   Updated=8926
INFO[05-10|13:15:20] Fetched                                  File=com.ubuntu.focal.cve.oval.xml.bz2 Count=10334 Timestamp=2022-05-10T02:54:58
INFO[05-10|13:15:21] Refreshing...                            Family=ubuntu Version=20
INFO[05-10|13:15:21] Inserting new Definitions... 
10332 / 10332 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 15036 p/s
INFO[05-10|13:15:22] Finish                                   Updated=10332
INFO[05-10|13:15:24] Fetched                                  File=com.ubuntu.bionic.cve.oval.xml.bz2 Count=15549 Timestamp=2022-05-10T02:54:55
INFO[05-10|13:15:25] Refreshing...                            Family=ubuntu Version=18
INFO[05-10|13:15:25] Inserting new Definitions... 
15530 / 15530 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 13074 p/s
INFO[05-10|13:15:27] Finish                                   Updated=15530
INFO[05-10|13:15:28] Fetched                                  File=com.ubuntu.xenial.cve.oval.xml.bz2 Count=20807 Timestamp=2022-05-10T03:56:36
INFO[05-10|13:15:29] Refreshing...                            Family=ubuntu Version=16
INFO[05-10|13:15:29] Inserting new Definitions... 
20766 / 20766 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 14691 p/s
INFO[05-10|13:15:31] Finish                                   Updated=20766
INFO[05-10|13:15:33] Fetched                                  File=com.ubuntu.trusty.cve.oval.xml.bz2 Count=22933 Timestamp=2022-05-10T02:55:02
INFO[05-10|13:15:34] Refreshing...                            Family=ubuntu Version=14
INFO[05-10|13:15:34] Inserting new Definitions... 
22855 / 22855 [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 19937 p/s
INFO[05-10|13:15:35] Finish                                   Updated=22855
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

