### PR TITLE
fix(fedora): support archive version

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -29,6 +29,9 @@ func init() {
 
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.oval.yaml)")
 
+	RootCmd.PersistentFlags().Bool("log-to-file", false, "output log to file")
+	_ = viper.BindPFlag("log-to-file", RootCmd.PersistentFlags().Lookup("log-to-file"))
+
 	RootCmd.PersistentFlags().String("log-dir", log.GetDefaultLogDir(), "/path/to/log")
 	_ = viper.BindPFlag("log-dir", RootCmd.PersistentFlags().Lookup("log-dir"))
 


### PR DESCRIPTION
# What did you implement:

Support for fetch in the archived version of Fedora.
Also, restore the `--log-to-file` flag.

Fixes #233, #236

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```console
$ goval-dictionary fetch fedora 32 33 --log-to-file --log-json --log-dir .
$ cat ./goval-dictionary.log | jq .msg | grep "CVEs for Fedora"
"240 CVEs for Fedora 32. Inserting to DB"
"263 CVEs for Fedora 33. Inserting to DB"
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

