### PR TITLE
refactor(ubuntu): change criterion walk

### DIFF
--- a/commands/fetch-ubuntu.go
+++ b/commands/fetch-ubuntu.go
@@ -89,10 +89,14 @@ func fetchUbuntu(_ *cobra.Command, args []string) (err error) {
 			log15.Warn("The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue.", "GitHub", "https://github.com/vulsio/goval-dictionary/issues", "OVAL", r.URL, "Timestamp", ovalroot.Generator.Timestamp)
 		}
 
+		defs, err := ubuntu.ConvertToModel(&ovalroot)
+		if err != nil {
+			return xerrors.Errorf("Failed to convert from OVAL to goval-dictionary model. err: %w", err)
+		}
 		root := models.Root{
 			Family:      c.Ubuntu,
 			OSVersion:   r.Target,
-			Definitions: ubuntu.ConvertToModel(&ovalroot),
+			Definitions: defs,
 			Timestamp:   time.Now(),
 		}
 

--- a/models/ubuntu/types.go
+++ b/models/ubuntu/types.go
@@ -241,3 +241,8 @@ type ConstantVariable struct {
 	Comment  string   `xml:"comment,attr"`
 	Value    []string `xml:"value"`
 }
+
+type dpkgInfoTest struct {
+	Name         string
+	FixedVersion string
+}

--- a/models/ubuntu/ubuntu_test.go
+++ b/models/ubuntu/ubuntu_test.go
@@ -9,133 +9,209 @@ import (
 	"github.com/vulsio/goval-dictionary/models"
 )
 
-func TestParseNotFixedYet(t *testing.T) {
+func TestCollectUbuntuPacks(t *testing.T) {
 	var tests = []struct {
-		comment  string
-		expected models.Package
+		cri      Criteria
+		tests    map[string]dpkgInfoTest
+		expected []models.Package
 	}{
-		// Ubuntu 14
 		{
-			comment: `The 'php-openid' package in trusty is affected and needs fixing.`,
-			expected: models.Package{
-				Name:        "php-openid",
-				NotFixedYet: true,
+			cri: Criteria{
+				Criterions: []Criterion{
+					{
+						TestRef: "oval:com.ubuntu.jammy:tst:200224390000040",
+						Comment: "gcc-snapshot package in jammy, is related to the CVE in some way and has been fixed (note: '20140405-0ubuntu1').",
+					},
+				},
+			},
+			tests: map[string]dpkgInfoTest{
+				"oval:com.ubuntu.jammy:tst:200224390000040": {
+					Name:         "gcc-snapshot",
+					FixedVersion: "0:20140405-0ubuntu1",
+				},
+			},
+			expected: []models.Package{},
+		},
+		{
+			cri: Criteria{
+				Criterions: []Criterion{
+					{
+						TestRef: "oval:com.ubuntu.jammy:tst:2018128860000050",
+						Comment: "gcc-snapshot: while related to the CVE in some way, a decision has been made to ignore this issue.",
+					},
+				},
+			},
+			tests: map[string]dpkgInfoTest{
+				"oval:com.ubuntu.jammy:tst:2018128860000050": {Name: "gcc-snapshot"},
+			},
+			expected: []models.Package{},
+		},
+		{
+			cri: Criteria{
+				Criterions: []Criterion{
+					{
+						TestRef: "oval:com.ubuntu.jammy:tst:200224390000000",
+						Comment: "gcc-arm-none-eabi package in jammy is affected and may need fixing.",
+					},
+				},
+			},
+			tests: map[string]dpkgInfoTest{
+				"oval:com.ubuntu.jammy:tst:200224390000000": {Name: "gcc-arm-none-eabi"},
+			},
+			expected: []models.Package{},
+		},
+		{
+			cri: Criteria{
+				Criterions: []Criterion{
+					{
+						TestRef: "oval:com.ubuntu.jammy:tst:200224390000000",
+						Comment: "gcc-arm-none-eabi package in jammy is affected and needs fixing.",
+					},
+				},
+			},
+			tests: map[string]dpkgInfoTest{
+				"oval:com.ubuntu.jammy:tst:200224390000000": {Name: "gcc-arm-none-eabi"},
+			},
+			expected: []models.Package{
+				{
+					Name:        "gcc-arm-none-eabi",
+					NotFixedYet: true,
+				},
 			},
 		},
-		// Ubuntu 16, 18
 		{
-			comment: `xine-console package in bionic is affected and needs fixing.`,
-			expected: models.Package{
-				Name:        "xine-console",
-				NotFixedYet: true,
+			cri: Criteria{
+				Criterions: []Criterion{
+					{
+						TestRef: "oval:com.ubuntu.jammy:tst:2018128860000050",
+						Comment: "gcc-snapshot package in jammy is affected, but a decision has been made to defer addressing it.",
+					},
+				},
+			},
+			tests: map[string]dpkgInfoTest{
+				"oval:com.ubuntu.jammy:tst:2018128860000050": {Name: "gcc-snapshot"},
+			},
+			expected: []models.Package{
+				{
+					Name:        "gcc-snapshot",
+					NotFixedYet: true,
+				},
+			},
+		},
+		{
+			cri: Criteria{
+				Criterions: []Criterion{
+					{
+						TestRef: "oval:com.ubuntu.xenial:tst:2020143720000010",
+						Comment: "grub2-unsigned package in xenial is affected. An update containing the fix has been completed and is pending publication (note: '2.04-1ubuntu42').",
+					},
+				},
+			},
+			tests: map[string]dpkgInfoTest{
+				"oval:com.ubuntu.xenial:tst:2020143720000010": {
+					Name:         "grub2-unsigned",
+					FixedVersion: "0:2.04-1ubuntu42",
+				},
+			},
+			expected: []models.Package{
+				{
+					Name:        "grub2-unsigned",
+					NotFixedYet: true,
+				},
+			},
+		},
+		{
+			cri: Criteria{
+				Criterions: []Criterion{
+					{
+						TestRef: "oval:com.ubuntu.jammy:tst:2021285440000000",
+						Comment: "subversion package in jammy was vulnerable but has been fixed (note: '1.14.1-3ubuntu0.22.04.1').",
+					},
+				},
+			},
+			tests: map[string]dpkgInfoTest{
+				"oval:com.ubuntu.jammy:tst:2021285440000000": {
+					Name:         "subversion",
+					FixedVersion: "0:1.14.1-3ubuntu0.22.04.1",
+				},
+			},
+			expected: []models.Package{
+				{
+					Name:        "subversion",
+					Version:     "0:1.14.1-3ubuntu0.22.04.1",
+					NotFixedYet: false,
+				},
+			},
+		},
+		{
+			cri: Criteria{
+				Criterions: []Criterion{
+					{
+						TestRef: "oval:com.ubuntu.jammy:tst:2021299550000000",
+						Comment: "firefox package in jammy was vulnerable and has been fixed, but no release version available for it.",
+					},
+				},
+			},
+			tests: map[string]dpkgInfoTest{
+				"oval:com.ubuntu.jammy:tst:2021299550000000": {Name: "firefox"},
+			},
+			expected: []models.Package{
+				{
+					Name:        "firefox",
+					Version:     "",
+					NotFixedYet: false,
+				},
+			},
+		},
+		{
+			cri: Criteria{
+				Criterions: []Criterion{
+					{
+						TestRef: "oval:com.ubuntu.jammy:tst:2016107230000000",
+						Comment: "Is kernel linux running",
+					},
+					{
+						TestRef: "oval:com.ubuntu.jammy:tst:2018121260000030",
+						Comment: "kernel version comparison",
+					},
+				},
+			},
+			tests:    map[string]dpkgInfoTest{},
+			expected: []models.Package{},
+		},
+		{
+			cri: Criteria{
+				Criterias: []Criteria{
+					{
+						Criterions: []Criterion{
+							{
+								TestRef: "oval:com.ubuntu.jammy:tst:200901660000010",
+								Comment: "poppler package in jammy was vulnerable but has been fixed (note: '0.10.5-1ubuntu2').",
+							},
+						},
+					},
+				},
+			},
+			tests: map[string]dpkgInfoTest{
+				"oval:com.ubuntu.jammy:tst:200901660000010": {
+					Name:         "poppler",
+					FixedVersion: "0:0.10.5-1ubuntu2",
+				},
+			},
+			expected: []models.Package{
+				{
+					Name:        "poppler",
+					Version:     "0:0.10.5-1ubuntu2",
+					NotFixedYet: false,
+				},
 			},
 		},
 	}
 
 	for i, tt := range tests {
-		actual, ok := parseNotFixedYet(tt.comment)
-		if !ok {
-			t.Errorf("[%d]: no match: %s\n", i, tt.comment)
-			return
-		}
-		if !reflect.DeepEqual(tt.expected, *actual) {
+		if actual := collectUbuntuPacks(tt.cri, tt.tests); !reflect.DeepEqual(tt.expected, actual) {
 			e := pp.Sprintf("%v", tt.expected)
-			a := pp.Sprintf("%v", *actual)
-			t.Errorf("[%d]: expected: %s\n, actual: %s\n", i, e, a)
-		}
-	}
-}
-
-func TestParseNotDecided(t *testing.T) {
-	var tests = []struct {
-		comment  string
-		expected models.Package
-	}{
-		// Ubuntu 14
-		{
-			comment: `The 'ruby1.9.1' package in trusty is affected, but a decision has been made to defer addressing it (note: '2019-04-10').`,
-			expected: models.Package{
-				Name:        "ruby1.9.1",
-				NotFixedYet: true,
-			},
-		},
-		// Ubuntu 16, 18
-		{
-			comment: `libxerces-c-samples package in bionic is affected, but a decision has been made to defer addressing it (note: '2019-01-01').`,
-			expected: models.Package{
-				Name:        "libxerces-c-samples",
-				NotFixedYet: true,
-			},
-		},
-		{
-			comment: `systemd package in bionic is affected, but a decision has been made to defer addressing it.`,
-			expected: models.Package{
-				Name:        "systemd",
-				NotFixedYet: true,
-			},
-		},
-	}
-
-	for i, tt := range tests {
-		actual, ok := parseNotDecided(tt.comment)
-		if !ok {
-			t.Errorf("[%d]: no match: %s\n", i, tt.comment)
-			return
-		}
-		if !reflect.DeepEqual(tt.expected, *actual) {
-			e := pp.Sprintf("%v", tt.expected)
-			a := pp.Sprintf("%v", *actual)
-			t.Errorf("[%d]: expected: %s\n, actual: %s\n", i, e, a)
-		}
-	}
-}
-
-func TestParseFixed(t *testing.T) {
-	var tests = []struct {
-		comment  string
-		ok       bool
-		expected models.Package
-	}{
-		{
-			comment: `The 'poppler' package in trusty was vulnerable but has been fixed (note: '0.10.5-1ubuntu2').`,
-			expected: models.Package{
-				Name:    "poppler",
-				Version: "0.10.5-1ubuntu2",
-			},
-			ok: true,
-		},
-		{
-			comment: `iproute2 package in bionic, is related to the CVE in some way and has been fixed (note: '3.12.0-2').`,
-			expected: models.Package{
-				Name:    "iproute2",
-				Version: "3.12.0-2",
-			},
-			ok: true,
-		},
-		{
-			comment: `iproute2 package in bionic, is related to the CVE in some way and has been fixed (note: '3.12.0-2 ').`,
-			expected: models.Package{
-				Name:    "iproute2",
-				Version: "3.12.0-2",
-			},
-			ok: true,
-		},
-		{
-			comment: "mysql-5.7 package in bionic, is related to the CVE in some way and has been fixed (note: '8.0 only').",
-			ok:      false,
-		},
-	}
-
-	for i, tt := range tests {
-		actual, ok := parseFixed(tt.comment)
-		if tt.ok != ok {
-			t.Errorf("[%d]: no match: %s\n", i, tt.comment)
-			return
-		}
-		if actual != nil && !reflect.DeepEqual(tt.expected, *actual) {
-			pp.ColoringEnabled = false
-			e := pp.Sprintf("%v", tt.expected)
-			a := pp.Sprintf("%v", *actual)
+			a := pp.Sprintf("%v", actual)
 			t.Errorf("[%d]: expected: %s\n, actual: %s\n", i, e, a)
 		}
 	}


### PR DESCRIPTION
# What did you implement:
The Ubuntu Fixed Package is for cases that match the following regular expressions.
https://github.com/vulsio/goval-dictionary/blob/8e6c8e373369934adedce93ef6e0f940db342513/models/ubuntu/ubuntu.go#L154-L175

This definition and [CVE-2022-28289 - Security Tracker](https://ubuntu.com/security/CVE-2022-28289) will explain the two cases of matching regular expressions.
```xml
<definition class="vulnerability" id="oval:com.ubuntu.jammy:def:2022282890000000" version="1">
    <metadata>
        <title>CVE-2022-28289 on Ubuntu 22.04 LTS (jammy) - medium.</title>
        <reference source="CVE" ref_id="CVE-2022-28289" ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28289" />
        <advisory>
            <ref>https://ubuntu.com/security/CVE-2022-28289</ref>
        </advisory>
    </metadata>
    <criteria>
        <extend_definition definition_ref="oval:com.ubuntu.jammy:def:100" comment="Ubuntu 22.04 LTS (jammy) is installed." applicability_check="true" />
        <criteria operator="OR">
            <criterion test_ref="oval:com.ubuntu.jammy:tst:2021459600000020" comment="firefox package in jammy was vulnerable but has been fixed (note: '1:1snap1-0ubuntu1')." />
            <criterion test_ref="oval:com.ubuntu.jammy:tst:2020160440000010" comment="mozjs78 package in jammy is affected and may need fixing." />
            <criterion test_ref="oval:com.ubuntu.jammy:tst:202211960000020" comment="mozjs91 package in jammy is affected and may need fixing." />
            <criterion test_ref="oval:com.ubuntu.jammy:tst:202210970000010" comment="thunderbird package in jammy, is related to the CVE in some way and has been fixed (note: '1:91.8.0+build2-0ubuntu1')." />
        </criteria>
    </criteria>
</definition>
```

The first case is `firefox package in jammy was vulnerable but has been fixed (note: '1:1snap1-0ubuntu1').
Security Tracker shows the following.
![image](https://user-images.githubusercontent.com/16035056/175497727-98f431e0-336e-45e8-8931-202e114877a6.png)

The second case is `thunderbird package in jammy, is related to the CVE in some way and has been fixed (note: '1:91.8.0+build2-0ubuntu1').`
![image](https://user-images.githubusercontent.com/16035056/175497762-e1c69dec-2eb2-4d93-a30c-aba943b68ea8.png)

The first case (`was vulnerable but has been fixed`) has a Status of Released, and the second case (`is related to the CVE in some way and has been fixed`) is Not vulnerable.
This is also verified by another criterion comment.

Next, we consider whether it is acceptable to treat the status of "Not vulnerable" as Affected Packages.
If look at [CVE-2008-3931 - Security Tracker](https://ubuntu.com/security/CVE-2008-3931), package: r-base, release: bionic, it says Not vulnerable (3.4.4-1 ubuntu1), but this CVE itself was fixed in 2.7.2-1, indicating that the version listed as Not vulnerable is not the fixed version.
There are many other cases like this. 
In addition, since Ubuntu, which provides advisory, has determined that packages are not vulnerable, packages with the status of Not vulnerable should not be classified as Affected Packages.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ goval-dictionary fetch ubuntu 22
$ goval-dictionary select --by-cveid ubuntu 22 CVE-2022-28289
CVE-2022-28289 on Ubuntu 22.04 LTS (jammy) - medium.
[{9039 9040 CVE-2022-28289     https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28289 }]
------------------
[]models.Definition{
  models.Definition{
    DefinitionID: "oval:com.ubuntu.jammy:def:2022282890000000",
    Title:        "CVE-2022-28289 on Ubuntu 22.04 LTS (jammy) - medium.",
    Advisory:     models.Advisory{
      Cves:         []models.Cve{
        models.Cve{
          CveID:      "CVE-2022-28289",
        },
      },
    },
    AffectedPacks: []models.Package{
      models.Package{
        Name:            "firefox",
        Version:         "1:1snap1-0ubuntu1",
        NotFixedYet:     false,
      },
      models.Package{
        Name:            "thunderbird",
        Version:         "1:91.8.0+build2-0ubuntu1",
        NotFixedYet:     false,
      },
    },
  },
}
```

## after
```console
$ goval-dictionary fetch ubuntu 22
$ goval-dictionary select --by-cveid ubuntu 22 CVE-2022-28289
CVE-2022-28289 on Ubuntu 22.04 LTS (jammy) - medium.
[{9039 9040 CVE-2022-28289     https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28289 }]
------------------
[]models.Definition{
  models.Definition{
    DefinitionID: "oval:com.ubuntu.jammy:def:2022282890000000",
    Title:        "CVE-2022-28289 on Ubuntu 22.04 LTS (jammy) - medium.",
    Advisory:     models.Advisory{
      Cves:         []models.Cve{
        models.Cve{
          CveID:      "CVE-2022-28289",
        },
      },
    },
    AffectedPacks: []models.Package{
      models.Package{
        Name:            "firefox",
        Version:         "1:1snap1-0ubuntu1",
        NotFixedYet:     false,
      },
    },
  },
}
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

