### PR TITLE
fix(GAdocker): version sub-command doesn't print version and revision

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,6 +39,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
+          context: .
           tags: |
             vuls/goval-dictionary:latest
             ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
# What did you implement:

I fixed that `version` sub-command doesn't print version and reivsion with docker container.
This problem is implemented at v0.4.0 (when GAdocker is first implemented).

```
$ docker run -it --rm vuls/goval-dictionary:latest version
goval-dictionary

$ docker run --rm vuls/goval-dictionary:0.3.5 -v
goval-dictionary v0.3.5 0a1e75f

$ docker run --rm vuls/goval-dictionary:v0.4.0 -v
goval-dictionary
```

With GitHub Actions docker build, version and revision couldn't specified because no `.git` in build context.

```
#0 0.097 fatal: not a git repository (or any of the parent directories): .git
#18 0.099 fatal: not a git repository (or any of the parent directories): .git
#18 0.101 fatal: not a git repository (or any of the parent directories): .git
```

cf. https://github.com/vulsio/goval-dictionary/actions/runs/2816188880/jobs/4445754546#step:7:403

I added context (that includes `.git`) to "Build and push" task in GitHub Actions configuration.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I pushed the fixed commit, issued the tag, and pushed the docker image to my DockerHub repository by GitHub Actions.
And I tested `version` sub-command works as expected.

```
$ docker run -it --rm ottijp/goval-dictionary:latest version
goval-dictionary  ce22a1e

$ docker run -it --rm ottijp/goval-dictionary:inspection03 version
goval-dictionary inspection03 ce22a1e
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] ~~Write tests~~
- [ ] ~~Write documentation~~
- [x] Check that there aren't other open pull requests for the same issue/feature
- [ ] ~~Format your source code by `make fmt`~~
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

