### PR TITLE
Support alpine 3.14+ package schema

### DIFF
--- a/commands/fetch-alpine.go
+++ b/commands/fetch-alpine.go
@@ -77,11 +77,16 @@ func fetchAlpine(_ *cobra.Command, args []string) (err error) {
 
 	osVerDefs := map[string][]models.Definition{}
 	for _, r := range results {
-		var secdb alpine.SecDB
-		if err := yaml.Unmarshal(r.Body, &secdb); err != nil {
+		var secdb alpine.SecDB[alpine.PackageType1]
+		if err := yaml.Unmarshal(r.Body, &secdb); err == nil {
+			osVerDefs[r.Target] = append(osVerDefs[r.Target], alpine.ConvertToModel(&secdb)...)
+			continue
+		}
+		var secdb2 alpine.SecDB[alpine.PackageType2]
+		if err := yaml.Unmarshal(r.Body, &secdb2); err != nil {
 			return xerrors.Errorf("Failed to unmarshal. err: %w", err)
 		}
-		osVerDefs[r.Target] = append(osVerDefs[r.Target], alpine.ConvertToModel(&secdb)...)
+		osVerDefs[r.Target] = append(osVerDefs[r.Target], alpine.ConvertToModel(&secdb2)...)
 	}
 
 	for osVer, defs := range osVerDefs {

--- a/models/alpine/alpine.go
+++ b/models/alpine/alpine.go
@@ -6,12 +6,11 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
-
 	"github.com/vulsio/goval-dictionary/models"
 )
 
-func (p PackageType1) extractCveIdPackages() []CveIdPackage {
-	cveIDPacks := []CveIdPackage{}
+func (p PackageType1) extractCveIDPackages() []CveIDPackage {
+	cveIDPacks := []CveIDPackage{}
 	for ver, vulnIDs := range p.Pkg.Secfixes {
 		for _, s := range vulnIDs {
 			cveID := strings.Split(s, " ")[0]
@@ -19,7 +18,7 @@ func (p PackageType1) extractCveIdPackages() []CveIdPackage {
 				continue
 			}
 
-			cveIDPacks = append(cveIDPacks, CveIdPackage{CveId: cveID, Package: models.Package{
+			cveIDPacks = append(cveIDPacks, CveIDPackage{CveID: cveID, Package: models.Package{
 				Name:    p.Pkg.Name,
 				Version: ver,
 			}})
@@ -28,8 +27,8 @@ func (p PackageType1) extractCveIdPackages() []CveIdPackage {
 	return cveIDPacks
 }
 
-func (p PackageType2) extractCveIdPackages() []CveIdPackage {
-	cveIDPacks := []CveIdPackage{}
+func (p PackageType2) extractCveIDPackages() []CveIDPackage {
+	cveIDPacks := []CveIDPackage{}
 	for _, secFix := range p.Pkg.Secfixes {
 		for _, fix := range secFix.Fixes {
 			for _, s := range fix.Identifiers {
@@ -38,7 +37,7 @@ func (p PackageType2) extractCveIdPackages() []CveIdPackage {
 					continue
 				}
 
-				cveIDPacks = append(cveIDPacks, CveIdPackage{CveId: cveID, Package: models.Package{
+				cveIDPacks = append(cveIDPacks, CveIDPackage{CveID: cveID, Package: models.Package{
 					Name:    p.Pkg.Name,
 					Version: secFix.Version,
 				}})
@@ -50,18 +49,18 @@ func (p PackageType2) extractCveIdPackages() []CveIdPackage {
 
 // ConvertToModel Convert OVAL to models
 func ConvertToModel[T PackageType](data *SecDB[T]) (defs []models.Definition) {
-	packs := []CveIdPackage{}
+	packs := []CveIDPackage{}
 	for _, pack := range data.Packages {
-		packs = append(packs, pack.extractCveIdPackages()...)
+		packs = append(packs, pack.extractCveIDPackages()...)
 	}
 
 	cveIDPacks := map[string][]models.Package{}
 	for _, pack := range packs {
-		if packs, ok := cveIDPacks[pack.CveId]; ok {
+		if packs, ok := cveIDPacks[pack.CveID]; ok {
 			packs = append(packs, pack.Package)
-			cveIDPacks[pack.CveId] = packs
+			cveIDPacks[pack.CveID] = packs
 		} else {
-			cveIDPacks[pack.CveId] = []models.Package{pack.Package}
+			cveIDPacks[pack.CveID] = []models.Package{pack.Package}
 		}
 	}
 

--- a/models/alpine/alpine_test.go
+++ b/models/alpine/alpine_test.go
@@ -1,13 +1,12 @@
 package alpine
 
 import (
-	"gopkg.in/yaml.v2"
 	"reflect"
 	"testing"
 
 	"github.com/k0kubun/pp"
-
 	"github.com/vulsio/goval-dictionary/models"
+	"gopkg.in/yaml.v2"
 )
 
 func TestExtractPackageType1(t *testing.T) {

--- a/models/alpine/alpine_test.go
+++ b/models/alpine/alpine_test.go
@@ -1,0 +1,119 @@
+package alpine
+
+import (
+	"gopkg.in/yaml.v2"
+	"reflect"
+	"testing"
+
+	"github.com/k0kubun/pp"
+
+	"github.com/vulsio/goval-dictionary/models"
+)
+
+func TestExtractPackageType1(t *testing.T) {
+	var tests = []struct {
+		oval     string
+		expected []models.Package
+	}{
+		{
+			oval: `
+apkurl: '{{urlprefix}}/{{distroversion}}/{{reponame}}/{{arch}}/{{pkg.name}}-{{pkg.ver}}.apk'
+archs:
+- aarch64
+- armhf
+- armv7
+- mips64
+- ppc64le
+- s390x
+- x86
+- x86_64
+reponame: main
+urlprefix: https://dl-cdn.alpinelinux.org/alpine
+distroversion: v3.13
+packages:
+- pkg:
+    name: sqlite
+    secfixes:
+      3.28.0-r0:
+      - CVE-2019-5018
+      - CVE-2019-8457
+            `,
+			expected: []models.Package{
+				{
+					Name:    "sqlite",
+					Version: "3.28.0-r0",
+				},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		var secDb SecDB[PackageType1]
+		if err := yaml.Unmarshal([]byte(tt.oval), &secDb); err != nil {
+			t.Errorf("[%d] marshall error %s", i, err.Error())
+		}
+
+		defs := ConvertToModel(&secDb)
+		actual := defs[0].AffectedPacks
+		if !reflect.DeepEqual(tt.expected, actual) {
+			e := pp.Sprintf("%v", tt.expected)
+			a := pp.Sprintf("%v", actual)
+			t.Errorf("[%d]: expected: %s\n, actual: %s\n", i, e, a)
+		}
+	}
+}
+
+func TestExtractPackageType2(t *testing.T) {
+	var tests = []struct {
+		oval     string
+		expected []models.Package
+	}{
+		{
+			oval: `
+apkurl: '{{urlprefix}}/{{distroversion}}/{{reponame}}/{{arch}}/{{pkg.name}}-{{pkg.ver}}.apk'
+archs:
+- aarch64
+- armhf
+- armv7
+- ppc64le
+- s390x
+- x86
+- x86_64
+reponame: main
+urlprefix: https://dl-cdn.alpinelinux.org/alpine
+distroversion: v3.14
+packages:
+- pkg:
+    name: sqlite
+    secfixes:
+    - version: 3.34.1-r0
+      fixes:
+      - identifiers:
+        - CVE-2021-20227
+        linenr: 37
+      linenr: 36
+            `,
+			expected: []models.Package{
+				{
+					Name:    "sqlite",
+					Version: "3.34.1-r0",
+				},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		var secDb SecDB[PackageType2]
+		if err := yaml.Unmarshal([]byte(tt.oval), &secDb); err != nil {
+			t.Errorf("[%d] marshall error %s", i, err.Error())
+		}
+
+		defs := ConvertToModel(&secDb)
+		actual := defs[0].AffectedPacks
+		if !reflect.DeepEqual(tt.expected, actual) {
+			e := pp.Sprintf("%v", tt.expected)
+			a := pp.Sprintf("%v", actual)
+			t.Errorf("[%d]: expected: %s\n, actual: %s\n", i, e, a)
+		}
+	}
+}

--- a/models/alpine/types.go
+++ b/models/alpine/types.go
@@ -1,15 +1,47 @@
 package alpine
 
+import "github.com/vulsio/goval-dictionary/models"
+
 // SecDB is a struct of alpine secdb
-type SecDB struct {
+type SecDB[T PackageType] struct {
 	Distroversion string
 	Reponame      string
 	Urlprefix     string
 	Apkurl        string
-	Packages      []struct {
-		Pkg struct {
-			Name     string
-			Secfixes map[string][]string
+	Packages      []T
+}
+
+// CveIdPackage is a struct of CVE-ID and package
+type CveIdPackage struct {
+	CveId   string
+	Package models.Package
+}
+
+// PackageType is interface for a alpine package type
+type PackageType interface {
+	PackageType1 | PackageType2
+	extractCveIdPackages() []CveIdPackage
+}
+
+// PackageType1 is the package struct of before alpine 3.14
+type PackageType1 struct {
+	Pkg struct {
+		Name     string
+		Secfixes map[string][]string
+	}
+}
+
+// PackageType2 is the package struct of after alpine 3.14
+type PackageType2 struct {
+	Pkg struct {
+		Name     string
+		Secfixes []struct {
+			Version string
+			Fixes   []struct {
+				Identifiers []string
+				Linenr      int64
+			}
+			Linenr int64
 		}
 	}
 }

--- a/models/alpine/types.go
+++ b/models/alpine/types.go
@@ -11,16 +11,16 @@ type SecDB[T PackageType] struct {
 	Packages      []T
 }
 
-// CveIdPackage is a struct of CVE-ID and package
-type CveIdPackage struct {
-	CveId   string
+// CveIDPackage is a struct of CVE-ID and package
+type CveIDPackage struct {
+	CveID   string
 	Package models.Package
 }
 
 // PackageType is interface for a alpine package type
 type PackageType interface {
 	PackageType1 | PackageType2
-	extractCveIdPackages() []CveIdPackage
+	extractCveIDPackages() []CveIDPackage
 }
 
 // PackageType1 is the package struct of before alpine 3.14


### PR DESCRIPTION
# What did you implement:

Alpine 3.14+ package schema has been changed since April 7th, resulting in Unmarshal error.
https://secdb.alpinelinux.org/
Fixed to be able to unmarshal both new and old schemas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## before

```bash
$ goval-dictionary fetch alpine --debug 3.14;
INFO[04-07|22:57:35] Fetching...                              URL=https://secdb.alpinelinux.org/v3.14/main.yaml
INFO[04-07|22:57:35] Fetching...                              URL=https://secdb.alpinelinux.org/v3.14/community.yaml
Failed to unmarshal. err: yaml: unmarshal errors:
  line 17: cannot unmarshal !!seq into map[string][]string
  line 107: cannot unmarshal !!seq into map[string][]string
  line 122: cannot unmarshal !!seq into map[string][]string
  line 395: cannot unmarshal !!seq into map[string][]string
  line 410: cannot unmarshal !!seq into map[string][]string
  line 419: cannot unmarshal !!seq into map[string][]string
  line 440: cannot unmarshal !!seq into map[string][]string
  line 455: cannot unmarshal !!seq into map[string][]string
  line 530: cannot unmarshal !!seq into map[string][]string

$ goval-dictionary fetch alpine --debug 3.13;
INFO[04-07|18:19:16] Fetching...                              URL=https://secdb.alpinelinux.org/v3.13/main.yaml
INFO[04-07|18:19:16] Fetching...                              URL=https://secdb.alpinelinux.org/v3.13/community.yaml
INFO[04-07|18:19:18] Refreshing...                            Family=alpine Version=3.13
INFO[04-07|18:19:18] Deleting old Definitions...
3740 / 3740 [-------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 4220 p/s
INFO[04-07|18:19:19] Inserting new Definitions...
3740 / 3740 [--------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 495 p/s
INFO[04-07|18:19:27] Finish                                   Updated=3740
```
## after

```bash
$ goval-dictionary fetch alpine --debug 3.14;
INFO[04-09|00:00:44] Fetching...                              URL=https://secdb.alpinelinux.org/v3.14/main.yaml
INFO[04-09|00:00:44] Fetching...                              URL=https://secdb.alpinelinux.org/v3.14/community.yaml
INFO[04-09|00:00:46] Refreshing...                            Family=alpine Version=3.14
INFO[04-09|00:00:46] Deleting old Definitions...
4322 / 4322 [-------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 4975 p/s
INFO[04-09|00:00:47] Inserting new Definitions...
4322 / 4322 [--------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 634 p/s
INFO[04-09|00:00:54] Finish                                   Updated=4322

$ goval-dictionary fetch alpine --debug 3.13;
INFO[04-09|00:03:05] Fetching...                              URL=https://secdb.alpinelinux.org/v3.13/main.yaml
INFO[04-09|00:03:05] Fetching...                              URL=https://secdb.alpinelinux.org/v3.13/community.yaml
INFO[04-09|00:03:08] Refreshing...                            Family=alpine Version=3.13
INFO[04-09|00:03:08] Deleting old Definitions...
3740 / 3740 [-------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 5391 p/s
INFO[04-09|00:03:09] Inserting new Definitions...
3740 / 3740 [--------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 633 p/s
INFO[04-09|00:03:15] Finish                                   Updated=3740
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

