### PR TITLE
fix(fetch/ubuntu): support oci oval

### DIFF
--- a/models/ubuntu/types.go
+++ b/models/ubuntu/types.go
@@ -99,20 +99,8 @@ type Bug struct {
 
 // Tests : >tests
 type Tests struct {
-	XMLName               xml.Name              `xml:"tests"`
-	FamilyTest            FamilyTest            `xml:"family_test"`
-	Textfilecontent54Test Textfilecontent54Test `xml:"textfilecontent54_test"`
-	DpkginfoTest          []DpkginfoTest        `xml:"dpkginfo_test"`
-}
-
-// FamilyTest : >tests>family_test
-type FamilyTest struct {
-	ID             string    `xml:"id,attr"`
-	Check          string    `xml:"check,attr"`
-	CheckExistence string    `xml:"check_existence,attr"`
-	Comment        string    `xml:"comment,attr"`
-	Object         ObjectRef `xml:"object"`
-	State          StateRef  `xml:"state"`
+	XMLName               xml.Name                `xml:"tests"`
+	Textfilecontent54Test []Textfilecontent54Test `xml:"textfilecontent54_test"`
 }
 
 // Textfilecontent54Test : >tests>textfilecontent54_test
@@ -125,28 +113,14 @@ type Textfilecontent54Test struct {
 	State          StateRef  `xml:"state"`
 }
 
-// DpkginfoTest : >tests>dpkginfo_test
-type DpkginfoTest struct {
-	ID             string    `xml:"id,attr"`
-	CheckExistence string    `xml:"check_existence,attr"`
-	Check          string    `xml:"check,attr"`
-	Comment        string    `xml:"comment,attr"`
-	Object         ObjectRef `xml:"object"`
-	State          StateRef  `xml:"state"`
-}
-
-// ObjectRef : >tests>family_test>object-object_ref
-//           : >tests>textfilecontent54_test>object-object_ref
-//           : >tests>dpkginfo_test>object-object_ref
+// ObjectRef : >tests>textfilecontent54_test>object-object_ref
 type ObjectRef struct {
 	XMLName   xml.Name `xml:"object"`
 	Text      string   `xml:",chardata"`
 	ObjectRef string   `xml:"object_ref,attr"`
 }
 
-// StateRef : >tests>family_test>state-state_ref
-//          : >tests>textfilecontent54_test>state-state_ref
-//          : >tests>dpkginfo_test>state-state_ref
+// StateRef : >tests>textfilecontent54_test>state-state_ref
 type StateRef struct {
 	XMLName  xml.Name `xml:"state"`
 	Text     string   `xml:",chardata"`
@@ -155,75 +129,45 @@ type StateRef struct {
 
 // Objects : >objects
 type Objects struct {
-	XMLName                 xml.Name                `xml:"objects"`
-	FamilyObject            FamilyObject            `xml:"family_object"`
-	Textfilecontent54Object Textfilecontent54Object `xml:"textfilecontent54_object"`
-	DpkginfoObject          []DpkginfoObject        `xml:"dpkginfo_object"`
-}
-
-// FamilyObject : >objects>family_object
-type FamilyObject struct {
-	ID      string `xml:"id,attr"`
-	Comment string `xml:"comment,attr"`
+	XMLName                 xml.Name                  `xml:"objects"`
+	Textfilecontent54Object []Textfilecontent54Object `xml:"textfilecontent54_object"`
 }
 
 // Textfilecontent54Object : >objects>textfilecontent54_object
 type Textfilecontent54Object struct {
 	ID       string `xml:"id,attr"`
 	Comment  string `xml:"comment,attr"`
-	Filepath string `xml:"filepath"`
+	Path     string `xml:"path"`
+	Filename string `xml:"filename"`
 	Pattern  struct {
 		Text      string `xml:",chardata"`
 		Operation string `xml:"operation,attr"`
+		Datatype  string `xml:"datatype,attr"`
+		VarRef    string `xml:"var_ref,attr"`
+		VarCheck  string `xml:"var_check,attr"`
 	} `xml:"pattern"`
 	Instance struct {
-		Text     string `xml:",chardata"`
-		Datatype string `xml:"datatype,attr"`
+		Text      string `xml:",chardata"`
+		Operation string `xml:"operation,attr"`
+		Datatype  string `xml:"datatype,attr"`
 	} `xml:"instance"`
-}
-
-// DpkginfoObject : >objects>dpkginfo_object
-type DpkginfoObject struct {
-	ID      string `xml:"id,attr"`
-	Comment string `xml:"comment,attr"`
-	Name    struct {
-		Text     string `xml:",chardata"`
-		VarRef   string `xml:"var_ref,attr"`
-		VarCheck string `xml:"var_check,attr"`
-	} `xml:"name"`
 }
 
 // States : >states
 type States struct {
-	XMLName                xml.Name               `xml:"states"`
-	FamilyState            FamilyState            `xml:"family_state"`
-	Textfilecontent54State Textfilecontent54State `xml:"textfilecontent54_state"`
-	DpkginfoState          []DpkginfoState        `xml:"dpkginfo_state"`
-}
-
-// FamilyState : >states>family_state
-type FamilyState struct {
-	ID      string `xml:"id,attr"`
-	Comment string `xml:"comment,attr"`
-	Family  string `xml:"family"`
+	XMLName                xml.Name                 `xml:"states"`
+	Textfilecontent54State []Textfilecontent54State `xml:"textfilecontent54_state"`
 }
 
 // Textfilecontent54State : >states>textfilecontent54_state
 type Textfilecontent54State struct {
 	ID            string `xml:"id,attr"`
 	Comment       string `xml:"comment,attr"`
-	Subexpression string `xml:"subexpression"`
-}
-
-// DpkginfoState : >states>dpkginfo_state
-type DpkginfoState struct {
-	ID      string `xml:"id,attr"`
-	Comment string `xml:"comment,attr"`
-	Evr     struct {
+	Subexpression struct {
 		Text      string `xml:",chardata"`
 		Datatype  string `xml:"datatype,attr"`
 		Operation string `xml:"operation,attr"`
-	} `xml:"evr"`
+	} `xml:"subexpression"`
 }
 
 // Variables : >variables

--- a/models/ubuntu/ubuntu_test.go
+++ b/models/ubuntu/ubuntu_test.go
@@ -44,7 +44,12 @@ func TestCollectUbuntuPacks(t *testing.T) {
 			tests: map[string]dpkgInfoTest{
 				"oval:com.ubuntu.jammy:tst:2018128860000050": {Name: "gcc-snapshot"},
 			},
-			expected: []models.Package{},
+			expected: []models.Package{
+				{
+					Name:        "gcc-snapshot",
+					NotFixedYet: true,
+				},
+			},
 		},
 		{
 			cri: Criteria{


### PR DESCRIPTION
# What did you implement:

fixed a bug that packages were not included when fetching

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ goval-dictionary fetch ubuntu 22.04
INFO[04-25|07:30:09] Fetching...                              URL=https://security-metadata.canonical.com/oval/oci.com.ubuntu.jammy.cve.oval.xml.bz2
INFO[04-25|07:30:13] Fetched                                  File=oci.com.ubuntu.jammy.cve.oval.xml.bz2 Count=11637 Timestamp=2023-04-24T21:10:16
WARN[04-25|07:30:13] Failed to parse string                   timeformat="[2006-01-02 2006-01-02 15:04:05 2006-01-02 15:04:05 +0000 2006-01-02 15:04:05 UTC]" target string="2023-02-14 10:00:00 PST"
WARN[04-25|07:30:13] Failed to parse string                   timeformat="[2006-01-02 2006-01-02 15:04:05 2006-01-02 15:04:05 +0000 2006-01-02 15:04:05 UTC]" target string="2023-02-14 10:00:00 PST"
WARN[04-25|07:30:13] Failed to parse string                   timeformat="[2006-01-02 2006-01-02 15:04:05 2006-01-02 15:04:05 +0000 2006-01-02 15:04:05 UTC]" target string="2023-02-14 17:00:00 CET"
INFO[04-25|07:30:13] Refreshing...                            Family=ubuntu Version=22.04
INFO[04-25|07:30:13] Inserting new Definitions... 
11633 / 11633 [-----------------------------------------------------------------------------------] 100.00% 121390 p/s
INFO[04-25|07:30:13] Finish                                   Updated=11633

$ sqlite3 oval.sqlite3 'SELECT COUNT(id) FROM packages'
0
```

## after
```console
$ goval-dictionary fetch ubuntu 22.04
INFO[04-25|07:32:18] Fetching...                              URL=https://security-metadata.canonical.com/oval/oci.com.ubuntu.jammy.cve.oval.xml.bz2
INFO[04-25|07:32:22] Fetched                                  File=oci.com.ubuntu.jammy.cve.oval.xml.bz2 Count=11637 Timestamp=2023-04-24T21:10:16
WARN[04-25|07:32:22] Failed to parse string                   timeformat="[2006-01-02 2006-01-02 15:04:05 2006-01-02 15:04:05 +0000 2006-01-02 15:04:05 UTC]" target string="2023-02-14 10:00:00 PST"
WARN[04-25|07:32:22] Failed to parse string                   timeformat="[2006-01-02 2006-01-02 15:04:05 2006-01-02 15:04:05 +0000 2006-01-02 15:04:05 UTC]" target string="2023-02-14 10:00:00 PST"
WARN[04-25|07:32:22] Failed to parse string                   timeformat="[2006-01-02 2006-01-02 15:04:05 2006-01-02 15:04:05 +0000 2006-01-02 15:04:05 UTC]" target string="2023-02-14 17:00:00 CET"
INFO[04-25|07:32:22] Refreshing...                            Family=ubuntu Version=22.04
INFO[04-25|07:32:23] Inserting new Definitions... 
11633 / 11633 [------------------------------------------------------------------------------------] 100.00% 53705 p/s
INFO[04-25|07:32:23] Finish                                   Updated=11633

$ sqlite3 oval.sqlite3 'SELECT COUNT(id) FROM packages'
13504
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
