### PR TITLE
fix(models/redhat): fix collectRedHatPacks

### DIFF
--- a/commands/fetch-redhat.go
+++ b/commands/fetch-redhat.go
@@ -92,7 +92,7 @@ func fetchRedHat(_ *cobra.Command, args []string) (err error) {
 		root := models.Root{
 			Family:      c.RedHat,
 			OSVersion:   v,
-			Definitions: redhat.ConvertToModel(roots),
+			Definitions: redhat.ConvertToModel(v, roots),
 			Timestamp:   time.Now(),
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/htcat/htcat v1.0.2
 	github.com/inconshreveable/log15 v3.0.0-testing.5+incompatible
 	github.com/k0kubun/pp v3.0.1+incompatible
+	github.com/knqyf263/go-rpm-version v0.0.0-20220614171824-631e686d1075
 	github.com/labstack/echo/v4 v4.10.2
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q
 github.com/k0kubun/pp v3.0.1+incompatible h1:3tqvf7QgUnZ5tXO6pNAZlrvHgl6DvifjDrd9g2S9Z40=
 github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/knqyf263/go-rpm-version v0.0.0-20220614171824-631e686d1075 h1:aC6MEAs3PE3lWD7lqrJfDxHd6hcced9R4JTZu85cJwU=
+github.com/knqyf263/go-rpm-version v0.0.0-20220614171824-631e686d1075/go.mod h1:i4sF0l1fFnY1aiw08QQSwVAFxHEm311Me3WsU/X7nL0=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/models/redhat/redhat_test.go
+++ b/models/redhat/redhat_test.go
@@ -12,11 +12,12 @@ import (
 
 func TestWalkRedHat(t *testing.T) {
 	var tests = []struct {
+		version  string
 		cri      Criteria
 		expected []models.Package
 	}{
-		// 0
 		{
+			version: "6",
 			cri: Criteria{
 				Criterions: []Criterion{
 					{Comment: "kernel-headers is earlier than 0:2.6.32-71.7.1.el6"},
@@ -29,8 +30,8 @@ func TestWalkRedHat(t *testing.T) {
 				},
 			},
 		},
-		// 1
 		{
+			version: "6",
 			cri: Criteria{
 				Criterias: []Criteria{
 					{
@@ -56,8 +57,8 @@ func TestWalkRedHat(t *testing.T) {
 				},
 			},
 		},
-		// 2
 		{
+			version: "6",
 			cri: Criteria{
 				Criterias: []Criteria{
 					{
@@ -106,32 +107,8 @@ func TestWalkRedHat(t *testing.T) {
 				},
 			},
 		},
-		// 3 dnf module
 		{
-			cri: Criteria{
-				Criterias: []Criteria{
-					{
-						Criterions: []Criterion{
-							{Comment: "ruby is earlier than 0:2.5.5-105.module+el8.1.0+3656+f80bfa1d"},
-							{Comment: "ruby is signed with Red Hat redhatrelease2 key"},
-						},
-					},
-				},
-				Criterions: []Criterion{
-					{Comment: "Red Hat Enterprise Linux 8 is installed"},
-					{Comment: "Module ruby:2.5 is enabled"},
-				},
-			},
-			expected: []models.Package{
-				{
-					Name:            "ruby",
-					Version:         "0:2.5.5-105.module+el8.1.0+3656+f80bfa1d",
-					ModularityLabel: "ruby:2.5",
-				},
-			},
-		},
-		// 4
-		{
+			version: "6",
 			cri: Criteria{
 				Criterias: []Criteria{
 					{
@@ -167,14 +144,129 @@ func TestWalkRedHat(t *testing.T) {
 				},
 			},
 		},
+		{
+			version: "6",
+			cri: Criteria{
+				Criterias: []Criteria{
+					{
+						Criterias: []Criteria{
+							{
+								Criterions: []Criterion{
+									{Comment: "rpm is earlier than 0:4.8.0-12.el6_0.2"},
+								},
+							},
+						},
+						Criterions: []Criterion{
+							{Comment: "Red Hat Enterprise Linux 6 is installed"},
+						},
+					},
+					{
+						Criterias: []Criteria{
+							{
+								Criterions: []Criterion{
+									{Comment: "rpm is earlier than 0:4.8.0-19.el7_0.1"},
+								},
+							},
+						},
+						Criterions: []Criterion{
+							{Comment: "Red Hat Enterprise Linux 7 is installed"},
+						},
+					},
+				},
+			},
+			expected: []models.Package{
+				{
+					Name:    "rpm",
+					Version: "0:4.8.0-12.el6_0.2",
+				},
+			},
+		},
+		{
+			version: "8",
+			cri: Criteria{
+				Criterias: []Criteria{
+					{
+						Criterions: []Criterion{
+							{Comment: "ruby is earlier than 0:2.5.5-105.module+el8.1.0+3656+f80bfa1d"},
+							{Comment: "ruby is signed with Red Hat redhatrelease2 key"},
+						},
+					},
+				},
+				Criterions: []Criterion{
+					{Comment: "Red Hat Enterprise Linux 8 is installed"},
+					{Comment: "Module ruby:2.5 is enabled"},
+				},
+			},
+			expected: []models.Package{
+				{
+					Name:            "ruby",
+					Version:         "0:2.5.5-105.module+el8.1.0+3656+f80bfa1d",
+					ModularityLabel: "ruby:2.5",
+				},
+			},
+		},
+		{
+			version: "8",
+			cri: Criteria{
+				Criterias: []Criteria{
+					{
+						Criterias: []Criteria{
+							{
+								Criterions: []Criterion{
+									{Comment: "libvirt is earlier than 0:4.5.0-42.module+el8.2.0+6024+15a2423f"},
+									{Comment: "libvirt is signed with Red Hat redhatrelease2 key"},
+								},
+							},
+						},
+						Criterions: []Criterion{
+							{Comment: "Module virt:rhel is enabled"},
+						},
+					},
+					{
+						Criterias: []Criteria{
+							{
+								Criterions: []Criterion{
+									{Comment: "libvirt is earlier than 0:4.5.0-42.module+el8.2.0+6024+15a2423f"},
+									{Comment: "libvirt is signed with Red Hat redhatrelease2 key"},
+								},
+							},
+						},
+						Criterions: []Criterion{
+							{Comment: "Module virt-devel:rhel is enabled"},
+						},
+					},
+				},
+				Criterions: []Criterion{
+					{Comment: "Red Hat Enterprise Linux 8 is installed"},
+				},
+			},
+			expected: []models.Package{
+				{
+					Name:            "libvirt",
+					Version:         "0:4.5.0-42.module+el8.2.0+6024+15a2423f",
+					ModularityLabel: "virt:rhel",
+				},
+				{
+					Name:            "libvirt",
+					Version:         "0:4.5.0-42.module+el8.2.0+6024+15a2423f",
+					ModularityLabel: "virt-devel:rhel",
+				},
+			},
+		},
 	}
 
 	for i, tt := range tests {
-		actual := collectRedHatPacks(tt.cri)
+		actual := collectRedHatPacks(tt.version, tt.cri)
 		sort.Slice(actual, func(i, j int) bool {
+			if actual[i].Name == actual[j].Name {
+				return actual[i].ModularityLabel < actual[j].ModularityLabel
+			}
 			return actual[i].Name < actual[j].Name
 		})
 		sort.Slice(tt.expected, func(i, j int) bool {
+			if tt.expected[i].Name == tt.expected[j].Name {
+				return tt.expected[i].ModularityLabel < tt.expected[j].ModularityLabel
+			}
 			return tt.expected[i].Name < tt.expected[j].Name
 		})
 


### PR DESCRIPTION
# What did you implement:

Fixed to include both packages when they have the same package name but different ModularityLabel.
And when importing packages that have the same package name but different versions, we used to rely on the order in which they were written in OVAL, but now we use the new version.
Then, OVALv1 defines non-RHEL5 package information among RHEL5 ones. We have tried to exclude such packages that are not the target version.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## same package name, but different ModularityLabel
### OVAL(OVALv2)
```xml
<definition class="patch" id="oval:com.redhat.rhsa:def:20202774" version="638">
    <metadata>
     <title>RHSA-2020:2774: virt:rhel security update (Important)</title>
     ...
    </metadata>
    <criteria operator="OR">
     <criterion comment="Red Hat Enterprise Linux must be installed" test_ref="oval:com.redhat.rhba:tst:20191992005"/>
     <criteria operator="AND">
      <criteria operator="OR">
       <criterion comment="Red Hat Enterprise Linux 8 is installed" test_ref="oval:com.redhat.rhba:tst:20191992003"/>
       <criterion comment="Red Hat CoreOS 4 is installed" test_ref="oval:com.redhat.rhba:tst:20191992004"/>
      </criteria>
      <criteria operator="OR">
       <criteria operator="AND">
        <criterion comment="Module virt:rhel is enabled" test_ref="oval:com.redhat.rhsa:tst:20191175195"/>
        <criteria operator="OR">
         <criteria operator="AND">
          <criterion comment="libvirt is earlier than 0:4.5.0-42.module+el8.2.0+6024+15a2423f" test_ref="oval:com.redhat.rhsa:tst:20202774051"/>
          <criterion comment="libvirt is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20191175054"/>
         </criteria>
         ...
        </criteria>
       </criteria>
       <criteria operator="AND">
        <criterion comment="Module virt-devel:rhel is enabled" test_ref="oval:com.redhat.rhsa:tst:20193345244"/>
        <criteria operator="OR">
         <criteria operator="AND">
          <criterion comment="libvirt is earlier than 0:4.5.0-42.module+el8.2.0+6024+15a2423f" test_ref="oval:com.redhat.rhsa:tst:20202774198"/>
          <criterion comment="libvirt is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20191175054"/>
         </criteria>
         ...
        </criteria>
       </criteria>
      </criteria>
     </criteria>
    </criteria>
</definition>
```

### before
```console
$ goval-dictionary fetch redhat 8
$ sqlite3 oval.sqlite3 'SELECT packages.name, packages.version, packages.modularity_label FROM definitions JOIN packages ON definitions.id = packages.definition_id WHERE definitions.definition_id = "oval:com.redhat.rhsa:def:20202774" AND packages.name = "libvirt"'
libvirt|0:4.5.0-42.module+el8.2.0+6024+15a2423f|virt-devel:rhel
```

### after
```console
$ goval-dictionary fetch redhat 8
$ sqlite3 oval.sqlite3 'SELECT packages.name, packages.version, packages.modularity_label FROM definitions JOIN packages ON definitions.id = packages.definition_id WHERE definitions.definition_id = "oval:com.redhat.rhsa:def:20202774" AND packages.name = "libvirt"'
libvirt|0:4.5.0-42.module+el8.2.0+6024+15a2423f|virt-devel:rhel
libvirt|0:4.5.0-42.module+el8.2.0+6024+15a2423f|virt:rhel
```

## same package name, but different package version
### OVAL(OVALv2)
```xml
<definition class="patch" id="oval:com.redhat.rhsa:def:20111349" version="638">
  <metadata>
   <title>RHSA-2011:1349: rpm security update (Important)</title>
   ...
  </metadata>
  <criteria operator="OR">
   <criterion comment="Red Hat Enterprise Linux must be installed" test_ref="oval:com.redhat.rhba:tst:20111656004"/>
   <criteria operator="AND">
    <criterion comment="Red Hat Enterprise Linux 6 is installed" test_ref="oval:com.redhat.rhba:tst:20111656003"/>
    <criteria operator="OR">
     <criteria operator="AND">
      <criterion comment="rpm is earlier than 0:4.8.0-12.el6_0.1" test_ref="oval:com.redhat.rhsa:tst:20111349001"/>
      <criterion comment="rpm is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20111349002"/>
     </criteria>
     ...
    </criteria>
   </criteria>
   <criteria operator="AND">
    <criterion comment="Red Hat Enterprise Linux 6 is installed" test_ref="oval:com.redhat.rhba:tst:20111656003"/>
    <criteria operator="OR">
     <criteria operator="AND">
      <criterion comment="rpm is earlier than 0:4.8.0-16.el6_1.1" test_ref="oval:com.redhat.rhsa:tst:20111349016"/>
      <criterion comment="rpm is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20111349002"/>
     </criteria>
     ...
    </criteria>
   </criteria>
  </criteria>
</definition>

<definition class="patch" id="oval:com.redhat.rhsa:def:20120451" version="638">
  <metadata>
   <title>RHSA-2012:0451: rpm security update (Important)</title>
   ...
  </metadata>
  <criteria operator="OR">
   <criterion comment="Red Hat Enterprise Linux must be installed" test_ref="oval:com.redhat.rhba:tst:20111656004"/>
   <criteria operator="AND">
    <criterion comment="Red Hat Enterprise Linux 6 is installed" test_ref="oval:com.redhat.rhba:tst:20111656003"/>
    <criteria operator="OR">
     <criteria operator="AND">
      <criterion comment="rpm is earlier than 0:4.8.0-12.el6_0.2" test_ref="oval:com.redhat.rhsa:tst:20120451001"/>
      <criterion comment="rpm is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20111349002"/>
     </criteria>
     ...
    </criteria>
   </criteria>
   <criteria operator="AND">
    <criterion comment="Red Hat Enterprise Linux 6 is installed" test_ref="oval:com.redhat.rhba:tst:20111656003"/>
    <criteria operator="OR">
     <criteria operator="AND">
      <criterion comment="rpm is earlier than 0:4.8.0-19.el6_2.1" test_ref="oval:com.redhat.rhsa:tst:20120451016"/>
      <criterion comment="rpm is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20111349002"/>
     </criteria>
     ...
    </criteria>
   </criteria>
  </criteria>
</definition>
```

```console
$ goval-dictionary fetch redhat 6
$ sqlite3 oval.sqlite3 'SELECT packages.name, packages.version, packages.modularity_label FROM definitions JOIN packages ON definitions.id = packages.definition_id WHERE definitions.definition_id = "oval:com.redhat.rhsa:def:20111349" AND packages.name = "rpm"'
rpm|0:4.8.0-16.el6_1.1|

$ sqlite3 oval.sqlite3 'SELECT packages.name, packages.version, packages.modularity_label FROM definitions JOIN packages ON definitions.id = packages.definition_id WHERE definitions.definition_id = "oval:com.redhat.rhsa:def:20120451" AND packages.name = "rpm"'
rpm|0:4.8.0-19.el6_2.1|
```

## not target RHEL version
### OVAL(OVALv1)
```xml
<definition class="patch" id="oval:com.redhat.rhsa:def:20100889" version="636">
 <metadata>
  <title>RHSA-2010:0889: freetype security update (Important)</title>
  ...
 </metadata>
 <criteria operator="OR">
  <criterion comment="Red Hat Enterprise Linux must be installed" test_ref="oval:com.redhat.rhba:tst:20070331006"/>
  <criteria operator="AND">
   <criterion comment="Red Hat Enterprise Linux 4 is installed" test_ref="oval:com.redhat.rhsa:tst:20070066005"/>
   <criteria operator="OR">
    <criteria operator="AND">
     <criterion comment="freetype is earlier than 0:2.1.9-17.el4_8.1" test_ref="oval:com.redhat.rhsa:tst:20100889001"/>
     <criterion comment="freetype is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20070150002"/>
    </criteria>
    <criteria operator="AND">
     <criterion comment="freetype-demos is earlier than 0:2.1.9-17.el4_8.1" test_ref="oval:com.redhat.rhsa:tst:20100889003"/>
     <criterion comment="freetype-demos is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20070150004"/>
    </criteria>
    <criteria operator="AND">
     <criterion comment="freetype-devel is earlier than 0:2.1.9-17.el4_8.1" test_ref="oval:com.redhat.rhsa:tst:20100889005"/>
     <criterion comment="freetype-devel is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20070150006"/>
    </criteria>
    <criteria operator="AND">
     <criterion comment="freetype-utils is earlier than 0:2.1.9-17.el4_8.1" test_ref="oval:com.redhat.rhsa:tst:20100889007"/>
     <criterion comment="freetype-utils is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20070150008"/>
    </criteria>
   </criteria>
  </criteria>
  <criteria operator="AND">
   <criterion comment="Red Hat Enterprise Linux 5 is installed" test_ref="oval:com.redhat.rhba:tst:20070331005"/>
   <criteria operator="OR">
    <criteria operator="AND">
     <criterion comment="freetype is earlier than 0:2.2.1-28.el5_5.1" test_ref="oval:com.redhat.rhsa:tst:20100889010"/>
     <criterion comment="freetype is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20070150002"/>
    </criteria>
    <criteria operator="AND">
     <criterion comment="freetype-demos is earlier than 0:2.2.1-28.el5_5.1" test_ref="oval:com.redhat.rhsa:tst:20100889011"/>
     <criterion comment="freetype-demos is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20070150004"/>
    </criteria>
    <criteria operator="AND">
     <criterion comment="freetype-devel is earlier than 0:2.2.1-28.el5_5.1" test_ref="oval:com.redhat.rhsa:tst:20100889012"/>
     <criterion comment="freetype-devel is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20070150006"/>
    </criteria>
   </criteria>
  </criteria>
  <criteria operator="AND">
   <criterion comment="Red Hat Enterprise Linux 6 is installed" test_ref="oval:com.redhat.rhsa:tst:20100889017"/>
   <criteria operator="OR">
    <criteria operator="AND">
     <criterion comment="freetype is earlier than 0:2.3.11-6.el6_0.2" test_ref="oval:com.redhat.rhsa:tst:20100889014"/>
     <criterion comment="freetype is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20070150002"/>
    </criteria>
    <criteria operator="AND">
     <criterion comment="freetype-demos is earlier than 0:2.3.11-6.el6_0.2" test_ref="oval:com.redhat.rhsa:tst:20100889015"/>
     <criterion comment="freetype-demos is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20070150004"/>
    </criteria>
    <criteria operator="AND">
     <criterion comment="freetype-devel is earlier than 0:2.3.11-6.el6_0.2" test_ref="oval:com.redhat.rhsa:tst:20100889016"/>
     <criterion comment="freetype-devel is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.rhsa:tst:20070150006"/>
    </criteria>
   </criteria>
  </criteria>
 </criteria>
```

### before
```console
$ goval-dictionary fetch redhat 5
$ sqlite3 oval.sqlite3 'SELECT COUNT(*) FROM packages WHERE packages.version LIKE "%.el6%" OR packages.version LIKE "%.el7%" OR packages.version LIKE "%.el8%" OR packages.version LIKE "%.el9%"'
1278
```

### after
```console
$ goval-dictionary fetch redhat 5
$ sqlite3 oval.sqlite3 'SELECT COUNT(*) FROM packages WHERE packages.version LIKE "%.el6%" OR packages.version LIKE "%.el7%" OR packages.version LIKE "%.el8%" OR packages.version LIKE "%.el9%"'
0
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

Is this ready for review?: YES

# Reference

* https://github.com/vulsio/goval-dictionary/pull/308

