### PR TITLE
feat(fetcher/ubuntu): remove 404 releases

### DIFF
--- a/fetcher/ubuntu/ubuntu.go
+++ b/fetcher/ubuntu/ubuntu.go
@@ -38,7 +38,6 @@ func getOVALURL(version string) string {
 	}
 
 	const main = "https://security-metadata.canonical.com/oval/oci.com.ubuntu.%s.cve.oval.xml.bz2"
-	const sub = "https://people.canonical.com/~ubuntu-security/oval/oci.com.ubuntu.%s.cve.oval.xml.bz2"
 	switch major {
 	case "4", "5", "6", "7", "8", "9", "10", "11", "12":
 		return "unsupported"
@@ -72,20 +71,13 @@ func getOVALURL(version string) string {
 			return "unknown"
 		}
 	case "19":
-		switch minor {
-		case "04":
-			return "unsupported"
-		case "10":
-			return fmt.Sprintf(sub, config.Ubuntu1910)
-		default:
-			return "unknown"
-		}
+		return "unsupported"
 	case "20":
 		switch minor {
 		case "04":
 			return fmt.Sprintf(main, config.Ubuntu2004)
 		case "10":
-			return fmt.Sprintf(sub, config.Ubuntu2010)
+			return "unsupported"
 		default:
 			return "unknown"
 		}


### PR DESCRIPTION
# What did you implement:

remove 19.10 and 20.10 OVALs as they are no longer available.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ goval-dictionary fetch ubuntu 19.10 20.10
INFO[06-12|14:44:28] Fetching...                              URL=https://people.canonical.com/~ubuntu-security/oval/oci.com.ubuntu.eoan.cve.oval.xml.bz2
INFO[06-12|14:44:28] Fetching...                              URL=https://people.canonical.com/~ubuntu-security/oval/oci.com.ubuntu.groovy.cve.oval.xml.bz2
Failed to fetch files. err: Failed to fetch. err: [Failed to write to output stream: Expected HTTP Status 200, received: "404 Not Found" Failed to write to output stream: Expected HTTP Status 200, received: "404 Not Found"]
```

## after
```console
$ goval-dictionary fetch ubuntu 19.10 20.10
WARN[06-12|14:43:53] Skip unsupported ubuntu version.         version=19.10
WARN[06-12|14:43:53] See https://wiki.ubuntu.com/Releases for supported versions 
WARN[06-12|14:43:53] Skip unsupported ubuntu version.         version=20.10
WARN[06-12|14:43:53] See https://wiki.ubuntu.com/Releases for supported versions 
Failed to fetch files. err: There are no versions to fetch
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

