### PR TITLE
fix(fetcher/debian): use bzip2 data

### DIFF
--- a/fetcher/debian/debian.go
+++ b/fetcher/debian/debian.go
@@ -12,7 +12,7 @@ import (
 
 // https://www.debian.org/security/oval/
 func newFetchRequests(target []string) (reqs []util.FetchRequest) {
-	const t = "https://www.debian.org/security/oval/oval-definitions-%s.xml"
+	const t = "https://www.debian.org/security/oval/oval-definitions-%s.xml.bz2"
 	for _, v := range target {
 		var name string
 		if name = debianName(v); name == "unknown" {
@@ -23,7 +23,7 @@ func newFetchRequests(target []string) (reqs []util.FetchRequest) {
 			Target:       v,
 			URL:          fmt.Sprintf(t, name),
 			Concurrently: true,
-			MIMEType:     util.MIMETypeXML,
+			MIMEType:     util.MIMETypeBzip2,
 		})
 	}
 	return


### PR DESCRIPTION
# What did you implement:

In Debian 12, the fetched data seems to be compressed with bzip2, even though xml is specified.

```console
$ wget https://www.debian.org/security/oval/oval-definitions-bookworm.xml
--2023-06-27 11:11:30--  https://www.debian.org/security/oval/oval-definitions-bookworm.xml
Resolving www.debian.org (www.debian.org)... 130.89.148.77, 149.20.4.15, 128.31.0.62, ...
Connecting to www.debian.org (www.debian.org)|130.89.148.77|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 2840845 (2.7M) [application/x-bzip2]
Saving to: ‘oval-definitions-bookworm.xml’

oval-definitions-bo 100%[===================>]   2.71M  1.27MB/s    in 2.1s    

2023-06-27 11:11:33 (1.27 MB/s) - ‘oval-definitions-bookworm.xml’ saved [2840845/2840845]

$ file --uncompress oval-definitions-bookworm.xml
oval-definitions-bookworm.xml: XML 1.0 document, ASCII text, with very long lines (922) (bzip2 compressed data, block size = 900k)
```
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ goval-dictionary fetch debian 12
goval-dictionary fetch debian 12
INFO[06-27|11:01:14] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-bookworm.xml
Failed to unmarshal xml. url: https://www.debian.org/security/oval/oval-definitions-bookworm.xml, err: XML syntax error on line 1: invalid character entity &SYk��� (no semicolon)
```

## after
```console
$ goval-dictionary fetch debian 7 8 9 10 11 12
INFO[06-27|11:06:37] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-jessie.xml.bz2
INFO[06-27|11:06:37] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-stretch.xml.bz2
INFO[06-27|11:06:37] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-buster.xml.bz2
INFO[06-27|11:06:37] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-bullseye.xml.bz2
INFO[06-27|11:06:37] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-bookworm.xml.bz2
INFO[06-27|11:06:37] Fetching...                              URL=https://www.debian.org/security/oval/oval-definitions-wheezy.xml.bz2
INFO[06-27|11:06:46] Fetched                                  File=oval-definitions-wheezy.xml.bz2 Count=3807 Timestamp=2023-06-26T23:36:36.188-04:00
INFO[06-27|11:06:46] Refreshing...                            Family=debian Version=7
INFO[06-27|11:06:46] Deleting old Definitions... 
3807 / 3807 [----------------------------------------------------] 100.00% ? p/s
INFO[06-27|11:06:46] Inserting new Definitions... 
3807 / 3807 [-------------------------------------------------] 100.00% 9010 p/s
INFO[06-27|11:06:46] Finish                                   Updated=3807
INFO[06-27|11:06:47] Fetched                                  File=oval-definitions-jessie.xml.bz2 Count=4811 Timestamp=2023-06-26T23:37:07.188-04:00
INFO[06-27|11:06:47] Refreshing...                            Family=debian Version=8
INFO[06-27|11:06:47] Deleting old Definitions... 
4811 / 4811 [------------------------------------------------] 100.00% 80494 p/s
INFO[06-27|11:06:47] Inserting new Definitions... 
4811 / 4811 [-------------------------------------------------] 100.00% 3047 p/s
INFO[06-27|11:06:49] Finish                                   Updated=4811
INFO[06-27|11:06:49] Fetched                                  File=oval-definitions-stretch.xml.bz2 Count=4532 Timestamp=2023-06-26T23:37:40.188-04:00
INFO[06-27|11:06:49] Refreshing...                            Family=debian Version=9
INFO[06-27|11:06:49] Deleting old Definitions... 
4532 / 4532 [------------------------------------------------] 100.00% 70349 p/s
INFO[06-27|11:06:49] Inserting new Definitions... 
4532 / 4532 [-------------------------------------------------] 100.00% 2694 p/s
INFO[06-27|11:06:51] Finish                                   Updated=4532
INFO[06-27|11:06:52] Fetched                                  File=oval-definitions-bookworm.xml.bz2 Count=25802 Timestamp=2023-06-26T23:40:16.188-04:00
INFO[06-27|11:06:52] Refreshing...                            Family=debian Version=12
INFO[06-27|11:06:52] Deleting old Definitions... 
25799 / 25799 [----------------------------------------------] 100.00% 45047 p/s
INFO[06-27|11:06:53] Inserting new Definitions... 
25799 / 25799 [----------------------------------------------] 100.00% 19096 p/s
INFO[06-27|11:06:55] Finish                                   Updated=25799
INFO[06-27|11:06:56] Fetched                                  File=oval-definitions-buster.xml.bz2 Count=26524 Timestamp=2023-06-26T23:38:21.188-04:00
INFO[06-27|11:06:56] Refreshing...                            Family=debian Version=10
INFO[06-27|11:06:56] Deleting old Definitions... 
26429 / 26429 [----------------------------------------------] 100.00% 43659 p/s
INFO[06-27|11:06:57] Inserting new Definitions... 
26522 / 26522 [----------------------------------------------] 100.00% 20725 p/s
INFO[06-27|11:06:58] Finish                                   Updated=26522
INFO[06-27|11:06:59] Fetched                                  File=oval-definitions-bullseye.xml.bz2 Count=27190 Timestamp=2023-06-26T23:39:19.188-04:00
INFO[06-27|11:07:00] Refreshing...                            Family=debian Version=11
INFO[06-27|11:07:00] Deleting old Definitions... 
27189 / 27189 [----------------------------------------------] 100.00% 42273 p/s
INFO[06-27|11:07:00] Inserting new Definitions... 
27189 / 27189 [----------------------------------------------] 100.00% 19711 p/s
INFO[06-27|11:07:02] Finish                                   Updated=27189
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

