### PR TITLE
fix(fetcher/redhat): fetch oval v1

### DIFF
--- a/commands/fetch-redhat.go
+++ b/commands/fetch-redhat.go
@@ -85,7 +85,7 @@ func fetchRedHat(_ *cobra.Command, args []string) (err error) {
 		}
 
 		roots := make([]redhat.Root, 0, len(m))
-		for _, k := range []string{fmt.Sprintf("rhel-%s.oval.xml.bz2", v), fmt.Sprintf("com.redhat.rhsa-RHEL%s.xml.bz2", v)} {
+		for _, k := range []string{fmt.Sprintf("rhel-%s.oval.xml.bz2", v), fmt.Sprintf("com.redhat.rhsa-RHEL%s.xml", v)} {
 			roots = append(roots, m[k])
 		}
 

--- a/fetcher/redhat/redhat.go
+++ b/fetcher/redhat/redhat.go
@@ -1,10 +1,16 @@
 package redhat
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"fmt"
+	"io"
+	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/inconshreveable/log15"
+	"golang.org/x/exp/slices"
 	"golang.org/x/xerrors"
 
 	"github.com/vulsio/goval-dictionary/fetcher/util"
@@ -13,6 +19,7 @@ import (
 // FetchFiles fetch OVAL from RedHat
 func FetchFiles(versions []string) (map[string][]util.FetchResult, error) {
 	results := map[string][]util.FetchResult{}
+	vs := make([]string, 0, len(versions))
 	for _, v := range versions {
 		n, err := strconv.Atoi(v)
 		if err != nil {
@@ -25,25 +32,72 @@ func FetchFiles(versions []string) (map[string][]util.FetchResult, error) {
 			continue
 		}
 
-		reqs := []util.FetchRequest{{
-			Target:   v,
-			URL:      fmt.Sprintf("https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL%s.xml.bz2", v),
-			MIMEType: util.MIMETypeBzip2,
-		}}
-		if n != 5 {
+		vs = append(vs, v)
+	}
+	if len(vs) == 0 {
+		return nil, xerrors.New("There are no versions to fetch")
+	}
+
+	log15.Info("Fetching... ", "URL", "https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz")
+	resp, err := http.Get("https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz")
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to get oval v1. err: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, xerrors.Errorf("Failed to get oval v1. err: bad status %d", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+
+	gr, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to create gzip reader. err: %w", err)
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, xerrors.Errorf("Failed to next tar reader. err: %w", err)
+		}
+
+		v := strings.TrimSuffix(strings.TrimPrefix(hdr.Name, "com.redhat.rhsa-RHEL"), ".xml")
+		if slices.Contains(vs, v) {
+			bs, err := io.ReadAll(tr)
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to read all com.redhat.rhsa-RHEL%s.xml. err: %w", v, err)
+			}
+			results[v] = append(results[v], util.FetchResult{
+				Target: v,
+				URL:    fmt.Sprintf("https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz/com.redhat.rhsa-RHEL%s.xml", v),
+				Body:   bs,
+			})
+		}
+	}
+
+	reqs := make([]util.FetchRequest, 0, len(vs))
+	for _, v := range vs {
+		if v != "5" {
 			reqs = append(reqs, util.FetchRequest{
 				Target:   v,
 				URL:      fmt.Sprintf("https://access.redhat.com/security/data/oval/v2/RHEL%s/rhel-%s.oval.xml.bz2", v, v),
 				MIMEType: util.MIMETypeBzip2,
 			})
 		}
-
+	}
+	if len(reqs) > 0 {
 		rs, err := util.FetchFeedFiles(reqs)
 		if err != nil {
 			return nil, xerrors.Errorf("Failed to fetch. err: %w", err)
 		}
-		results[v] = append(results[v], rs...)
+		for _, r := range rs {
+			results[r.Target] = append(results[r.Target], r)
+		}
 	}
+
 	if len(results) == 0 {
 		return nil, xerrors.New("There are no versions to fetch")
 	}


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Fixes #322 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ goval-dictionary fetch redhat 5 6 7 8 9
INFO[07-14|03:35:45] Fetching...                              URL=https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL6.xml.bz2
INFO[07-14|03:35:45] Fetching...                              URL=https://access.redhat.com/security/data/oval/v2/RHEL6/rhel-6.oval.xml.bz2
Failed to fetch files. err: Failed to fetch. err: [Failed to HTTP GET. url: https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL6.xml.bz2, response: &{Status:404 Not Found StatusCode:404 Proto:HTTP/2.0 ProtoMajor:2 ProtoMinor:0 Header:map[Accept-Ranges:[bytes] Cache-Control:[max-age=0, no-cache, no-store] Content-Length:[4175] Content-Type:[text/html] Date:[Thu, 13 Jul 2023 18:35:47 GMT] Etag:["ae034f3a82c72cf3e42fbff031eb884e:1605205643.329165"] Expires:[Thu, 13 Jul 2023 18:35:47 GMT] Last-Modified:[Thu, 12 Nov 2020 18:26:58 GMT] Pragma:[no-cache] Server:[AkamaiNetStorage]] Body:{cs:0xc000148900} ContentLength:4175 TransferEncoding:[] Close:false Uncompressed:false Trailer:map[] Request:0xc000140000 TLS:0xc00014c210}]
```

## after
```console
$ goval-dictionary fetch redhat 5 6 7 8 9
INFO[07-14|12:08:53] Fetching...                              URL=https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz
INFO[07-14|12:08:56] Fetching...                              URL=https://access.redhat.com/security/data/oval/v2/RHEL6/rhel-6.oval.xml.bz2
INFO[07-14|12:08:56] Fetching...                              URL=https://access.redhat.com/security/data/oval/v2/RHEL7/rhel-7.oval.xml.bz2
INFO[07-14|12:08:56] Fetching...                              URL=https://access.redhat.com/security/data/oval/v2/RHEL8/rhel-8.oval.xml.bz2
INFO[07-14|12:08:56] Fetching...                              URL=https://access.redhat.com/security/data/oval/v2/RHEL9/rhel-9.oval.xml.bz2
INFO[07-14|12:08:57] Fetched                                  File=com.redhat.rhsa-RHEL6.xml Count=1293 Timestamp=2023-04-05T15:46:45
WARN[07-14|12:08:57] The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue. GitHub=https://github.com/vulsio/goval-dictionary/issues OVAL=https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz/com.redhat.rhsa-RHEL6.xml Timestamp=2023-04-05T15:46:45
INFO[07-14|12:08:57] Fetched                                  File=rhel-6.oval.xml.bz2 Count=1555 Timestamp=2023-07-08T11:19:14
WARN[07-14|12:08:57] The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue. GitHub=https://github.com/vulsio/goval-dictionary/issues OVAL=https://access.redhat.com/security/data/oval/v2/RHEL6/rhel-6.oval.xml.bz2 Timestamp=2023-07-08T11:19:14
INFO[07-14|12:08:57] Refreshing...                            Family=redhat Version=6
INFO[07-14|12:08:57] Inserting new Definitions... 
1645 / 1645 [------------------------------------------------] 100.00% 10280 p/s
INFO[07-14|12:08:58] Finish                                   Updated=1645
INFO[07-14|12:08:58] Fetched                                  File=com.redhat.rhsa-RHEL7.xml Count=1478 Timestamp=2023-04-05T15:46:45
WARN[07-14|12:08:58] The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue. GitHub=https://github.com/vulsio/goval-dictionary/issues OVAL=https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz/com.redhat.rhsa-RHEL7.xml Timestamp=2023-04-05T15:46:45
INFO[07-14|12:08:59] Fetched                                  File=rhel-7.oval.xml.bz2 Count=1508 Timestamp=2023-07-13T15:00:01
INFO[07-14|12:08:59] Refreshing...                            Family=redhat Version=7
INFO[07-14|12:08:59] Inserting new Definitions... 
1562 / 1562 [-------------------------------------------------] 100.00% 9732 p/s
INFO[07-14|12:08:59] Finish                                   Updated=1562
INFO[07-14|12:08:59] Fetched                                  File=com.redhat.rhsa-RHEL8.xml Count=1156 Timestamp=2023-04-05T15:46:46
WARN[07-14|12:08:59] The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue. GitHub=https://github.com/vulsio/goval-dictionary/issues OVAL=https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz/com.redhat.rhsa-RHEL8.xml Timestamp=2023-04-05T15:46:46
INFO[07-14|12:09:00] Fetched                                  File=rhel-8.oval.xml.bz2 Count=1260 Timestamp=2023-07-13T15:01:00
INFO[07-14|12:09:00] Refreshing...                            Family=redhat Version=8
INFO[07-14|12:09:00] Inserting new Definitions... 
1260 / 1260 [-------------------------------------------------] 100.00% 7470 p/s
INFO[07-14|12:09:00] Finish                                   Updated=1260
INFO[07-14|12:09:00] Fetched                                  File=com.redhat.rhsa-RHEL9.xml Count=222 Timestamp=2023-04-05T15:46:46
WARN[07-14|12:09:00] The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue. GitHub=https://github.com/vulsio/goval-dictionary/issues OVAL=https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz/com.redhat.rhsa-RHEL9.xml Timestamp=2023-04-05T15:46:46
INFO[07-14|12:09:00] Fetched                                  File=rhel-9.oval.xml.bz2 Count=335 Timestamp=2023-07-13T15:00:21
INFO[07-14|12:09:00] Refreshing...                            Family=redhat Version=9
INFO[07-14|12:09:00] Inserting new Definitions... 
335 / 335 [------------------------------------------------------] 100.00% ? p/s
INFO[07-14|12:09:00] Finish                                   Updated=335
INFO[07-14|12:09:01] Fetched                                  File=com.redhat.rhsa-RHEL5.xml Count=1172 Timestamp=2023-04-05T15:46:45
WARN[07-14|12:09:01] The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue. GitHub=https://github.com/vulsio/goval-dictionary/issues OVAL=https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz/com.redhat.rhsa-RHEL5.xml Timestamp=2023-04-05T15:46:45
INFO[07-14|12:09:01] Refreshing...                            Family=redhat Version=5
INFO[07-14|12:09:01] Inserting new Definitions... 
1172 / 1172 [------------------------------------------------] 100.00% 29167 p/s
INFO[07-14|12:09:01] Finish                                   Updated=1172
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

