### PR TITLE
refactor(db): return err if version cannot be determined

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -180,6 +180,30 @@ func Test_formatFamilyAndOSVer(t *testing.T) {
 		},
 		{
 			in: args{
+				family: config.Amazon,
+				osVer:  "2018.03",
+			},
+			expected: args{
+				family: config.Amazon,
+				osVer:  "1",
+			},
+		},
+		{
+			in: args{
+				family: config.Amazon,
+				osVer:  "2018",
+			},
+			wantErr: `Failed to detect amazon version. err: unexpected Amazon Linux 1 version format. expected: "yyyy.MM", actual: "2018"`,
+		},
+		{
+			in: args{
+				family: config.Amazon,
+				osVer:  "2023.3.20240312",
+			},
+			wantErr: `Failed to detect amazon version. err: unexpected Amazon Linux 1 version format. expected: "yyyy.MM", actual: "2023.3.20240312"`,
+		},
+		{
+			in: args{
 				family: config.Alpine,
 				osVer:  "3.15",
 			},


### PR DESCRIPTION
# What did you implement:

On Amazon Linux, return err if version cannot be determined.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?


# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

