### PR TITLE
fix(fetch/ubuntu): fix timezone warning

### DIFF
--- a/models/ubuntu/ubuntu.go
+++ b/models/ubuntu/ubuntu.go
@@ -128,7 +128,7 @@ func parseDefinitions(ovalDefs []Definition, tests map[string]dpkgInfoTest) []mo
 			})
 		}
 
-		date := util.ParsedOrDefaultTime([]string{"2006-01-02", "2006-01-02 15:04:05", "2006-01-02 15:04:05 +0000", "2006-01-02 15:04:05 UTC"}, d.Advisory.PublicDate)
+		date := util.ParsedOrDefaultTime([]string{"2006-01-02", "2006-01-02 15:04:05", "2006-01-02 15:04:05 +0000", "2006-01-02 15:04:05 MST"}, d.Advisory.PublicDate)
 
 		def := models.Definition{
 			DefinitionID: d.ID,


### PR DESCRIPTION
# What did you implement:

fixed warning with timezone

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## sample case
```xml
<definition class="vulnerability" id="oval:com.ubuntu.jammy:def:2023257250000000" version="1">
    <metadata>
        <title>CVE-2023-25725 on Ubuntu 22.04 LTS (jammy) - medium.</title>
        <description>HAProxy before 2.7.3 may allow a bypass of access control because HTTP/1 headers are inadvertently
            lost in some situations, aka "request smuggling." The HTTP header parsers in HAProxy may accept empty header
            field names, which could be used to truncate the list of HTTP headers and thus make some headers disappear
            after being parsed and processed for HTTP/1.0 and HTTP/1.1. For HTTP/2 and HTTP/3, the impact is limited
            because the headers disappear before being parsed and processed, as if they had not been sent by the client.
            The fixed versions are 2.7.3, 2.6.9, 2.5.12, 2.4.22, 2.2.29, and 2.0.31.

            Update Instructions:

            Run `sudo pro fix CVE-2023-25725` to fix the vulnerability. The problem can be corrected
            by updating your system to the following package versions:

            haproxy - 2.4.18-0ubuntu1.2
            vim-haproxy - 2.4.18-0ubuntu1.2
            No subscription required</description>
        <affected family="unix">
            <platform>Ubuntu 22.04 LTS</platform>
        </affected>
        <reference source="CVE" ref_id="CVE-2023-25725"
            ref_url="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-25725" />
        <advisory>
            <severity>Medium</severity>
            <rights>Copyright (C) 2023 Canonical Ltd.</rights>
            <public_date>2023-02-14 17:00:00 CET</public_date>
            <public_date_at_usn>2023-02-14 17:00:00 CET</public_date_at_usn>
            <assigned_to>mdeslaur</assigned_to>
            <discovered_by>Bahruz Jabiyev, Anthony Gavazzi, Engin Kirda, Kaan
                Onarlioglu, Adi Peleg, and Harvey Tuch</discovered_by>
            <crd>2023-02-14 17:00:00 CET</crd>
            <cve href="https://ubuntu.com/security/CVE-2023-25725" severity="medium" public="20230214" cvss_score="9.1"
                cvss_vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H" usns="5869-1">CVE-2023-25725</cve>
        </advisory>
    </metadata>
    <criteria>

        <criterion test_ref="oval:com.ubuntu.jammy:tst:2023257250000000"
            comment="haproxy package in jammy was vulnerable but has been fixed (note: '2.4.18-0ubuntu1.2')." />
    </criteria>
</definition>
```

## before
```console
$ goval-dictionary fetch ubuntu 22.04
INFO[07-22|22:10:33] Fetching...                              URL=https://security-metadata.canonical.com/oval/oci.com.ubuntu.jammy.cve.oval.xml.bz2
INFO[07-22|22:10:39] Fetched                                  File=oci.com.ubuntu.jammy.cve.oval.xml.bz2 Count=12331 Timestamp=2023-07-22T10:33:17
WARN[07-22|22:10:39] Failed to parse string                   timeformat="[2006-01-02 2006-01-02 15:04:05 2006-01-02 15:04:05 +0000 2006-01-02 15:04:05 UTC]" target string="2023-02-14 17:00:00 CET"
WARN[07-22|22:10:39] Failed to parse string                   timeformat="[2006-01-02 2006-01-02 15:04:05 2006-01-02 15:04:05 +0000 2006-01-02 15:04:05 UTC]" target string="2023-04-25 10:00:00 PDT"
WARN[07-22|22:10:39] Failed to parse string                   timeformat="[2006-01-02 2006-01-02 15:04:05 2006-01-02 15:04:05 +0000 2006-01-02 15:04:05 UTC]" target string="2023-06-22 12:00:00 CET"
WARN[07-22|22:10:39] Failed to parse string                   timeformat="[2006-01-02 2006-01-02 15:04:05 2006-01-02 15:04:05 +0000 2006-01-02 15:04:05 UTC]" target string="2023-02-14 10:00:00 PST"
WARN[07-22|22:10:39] Failed to parse string                   timeformat="[2006-01-02 2006-01-02 15:04:05 2006-01-02 15:04:05 +0000 2006-01-02 15:04:05 UTC]" target string="2023-02-14 10:00:00 PST"
WARN[07-22|22:10:39] Failed to parse string                   timeformat="[2006-01-02 2006-01-02 15:04:05 2006-01-02 15:04:05 +0000 2006-01-02 15:04:05 UTC]" target string="2023-04-25 10:00:00 PDT"
WARN[07-22|22:10:39] Failed to parse string                   timeformat="[2006-01-02 2006-01-02 15:04:05 2006-01-02 15:04:05 +0000 2006-01-02 15:04:05 UTC]" target string="2023-04-25 10:00:00 PDT"
WARN[07-22|22:10:39] Failed to parse string                   timeformat="[2006-01-02 2006-01-02 15:04:05 2006-01-02 15:04:05 +0000 2006-01-02 15:04:05 UTC]" target string="2023-06-01 12:00:00 CET"
INFO[07-22|22:10:39] Refreshing...                            Family=ubuntu Version=22.04
INFO[07-22|22:10:39] Inserting new Definitions... 
12328 / 12328 [----------------------------------------------] 100.00% 30597 p/s
INFO[07-22|22:10:40] Finish                                   Updated=12328

$ sqlite3 oval.sqlite3 'SELECT issued, updated FROM advisories JOIN definitions ON definitions.id = advisories.definition_id WHERE definitions.definition_id = "oval:com.ubuntu.jammy:def:2023257250000000"'
1000-01-01 00:00:00+00:00|1000-01-01 00:00:00+00:00
```

## after
```console
$ goval-dictionary fetch ubuntu 22.04
INFO[07-22|22:19:38] Fetching...                              URL=https://security-metadata.canonical.com/oval/oci.com.ubuntu.jammy.cve.oval.xml.bz2
INFO[07-22|22:19:42] Fetched                                  File=oci.com.ubuntu.jammy.cve.oval.xml.bz2 Count=12331 Timestamp=2023-07-22T10:33:17
INFO[07-22|22:19:42] Refreshing...                            Family=ubuntu Version=22.04
INFO[07-22|22:19:42] Inserting new Definitions... 
12328 / 12328 [----------------------------------------------] 100.00% 34562 p/s
INFO[07-22|22:19:42] Finish                                   Updated=12328

$ sqlite3 oval.sqlite3 'SELECT issued, updated FROM advisories JOIN definitions ON definitions.id = advisories.definition_id WHERE definitions.definition_id = "oval:com.ubuntu.jammy:def:2023257250000000"'
2023-02-14 17:00:00+00:00|2023-02-14 17:00:00+00:00
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

