### PR TITLE
fix(fetcher/fedora): change archive version

### DIFF
--- a/fetcher/fedora/fedora.go
+++ b/fetcher/fedora/fedora.go
@@ -88,7 +88,7 @@ func newFedoraFetchRequests(target []string, arch string) (reqs []util.FetchRequ
 		case n < 32:
 			log15.Warn("Skip fedora because no vulnerability information provided.", "version", v)
 			continue
-		case n < 36:
+		case n < 37:
 			updateURL = archiveUpdateURL
 			moduleURL = archiveModuleURL
 		default:


### PR DESCRIPTION
# What did you implement:

Fixes #330 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ goval-dictionary fetch fedora 36
INFO[08-01|13:38:11] start fetch data from repomd.xml of non-modular package 
INFO[08-01|13:38:11] Fetching...                              URL=https://dl.fedoraproject.org/pub/fedora/linux/updates/36/Everything/x86_64/repodata/repomd.xml
Failed to fetch files. err: fetchEverythingFedora. err: Failed to fetch feed file, err: Failed to fetch. err: [Failed to write to output stream: Expected HTTP Status 200, received: "404 Not Found"]
```

## after
```console
$ goval-dictionary fetch fedora 36
INFO[08-01|13:39:22] start fetch data from repomd.xml of non-modular package 
INFO[08-01|13:39:22] Fetching...                              URL=https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/36/Everything/x86_64/repodata/repomd.xml
INFO[08-01|13:39:22] start fetch updateinfo in repomd.xml 
INFO[08-01|13:39:22] Fetching...                              URL=https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/36/Everything/x86_64/repodata/6bb4469f3b2efc11d968f799fa249ee3d46b843289abea86fb8ee9e87d54cd29-updateinfo.xml.xz
INFO[08-01|13:39:26] Fetch CVE-ID list from bugzilla.redhat.com URL="https://bugzilla.redhat.com/show_bug.cgi?ctype=xml&id=2162320"
INFO[08-01|13:39:29] 20 CVE-IDs fetched 
INFO[08-01|13:39:29] start fetch data from repomd.xml of modular 
INFO[08-01|13:39:29] Fetching...                              URL=https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/36/Modular/x86_64/repodata/repomd.xml
INFO[08-01|13:39:30] start fetch updateinfo in repomd.xml 
INFO[08-01|13:39:30] Fetching...                              URL=https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/36/Modular/x86_64/repodata/27781ed5d29f467776ec13602fa3e3f16666b44bd09fc2deac67a736a66c1510-updateinfo.xml.xz
INFO[08-01|13:39:30] start fetch modules.yaml in repomd.xml 
INFO[08-01|13:39:30] Fetching...                              URL=https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/36/Modular/x86_64/repodata/fbc6db8242c5d404277fd3dad47c19cf983f9600faae3178d47b93f81a6ddb62-modules.yaml.gz
INFO[08-01|13:39:30] start fetch data from repomd.xml of non-modular package 
INFO[08-01|13:39:30] Fetching...                              URL=https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/36/Everything/aarch64/repodata/repomd.xml
INFO[08-01|13:39:30] start fetch updateinfo in repomd.xml 
INFO[08-01|13:39:30] Fetching...                              URL=https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/36/Everything/aarch64/repodata/6bb4469f3b2efc11d968f799fa249ee3d46b843289abea86fb8ee9e87d54cd29-updateinfo.xml.xz
INFO[08-01|13:39:34] Fetch CVE-ID list from bugzilla.redhat.com URL="https://bugzilla.redhat.com/show_bug.cgi?ctype=xml&id=2162320"
INFO[08-01|13:39:36] 20 CVE-IDs fetched 
INFO[08-01|13:39:36] start fetch data from repomd.xml of modular 
INFO[08-01|13:39:36] Fetching...                              URL=https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/36/Modular/aarch64/repodata/repomd.xml
INFO[08-01|13:39:36] start fetch updateinfo in repomd.xml 
INFO[08-01|13:39:36] Fetching...                              URL=https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/36/Modular/aarch64/repodata/27781ed5d29f467776ec13602fa3e3f16666b44bd09fc2deac67a736a66c1510-updateinfo.xml.xz
INFO[08-01|13:39:36] start fetch modules.yaml in repomd.xml 
INFO[08-01|13:39:36] Fetching...                              URL=https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/36/Modular/aarch64/repodata/2492b6c034ba60eccee782d37fdb391f38813d894a20bad4d76a21bef3c1564b-modules.yaml.gz
INFO[08-01|13:39:37] 258 Advisories for Fedora 36 Fetched 
INFO[08-01|13:39:37] 258 CVEs for Fedora 36. Inserting to DB 
INFO[08-01|13:39:37] Refreshing...                            Family=fedora Version=36
INFO[08-01|13:39:37] Inserting new Definitions... 
258 / 258 [---------------------------------------------------] 100.00% 2641 p/s
INFO[08-01|13:39:37] Finish                                   Updated=258
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

