### PR TITLE
feat(fetcher): don't do concurrency fetch by htcat and set User-Agent

### DIFF
--- a/fetcher/amazon/amazon.go
+++ b/fetcher/amazon/amazon.go
@@ -148,10 +148,9 @@ func fetchUpdateInfoURL(mirrors []string) (updateInfoURLs []string, err error) {
 		}
 		u.Path = path.Join(u.Path, "/repodata/repomd.xml")
 		reqs = append(reqs, util.FetchRequest{
-			Target:       mirror, // base URL of the mirror site
-			URL:          u.String(),
-			Concurrently: true,
-			MIMEType:     util.MIMETypeXML,
+			Target:   mirror, // base URL of the mirror site
+			URL:      u.String(),
+			MIMEType: util.MIMETypeXML,
 		})
 	}
 

--- a/fetcher/debian/debian.go
+++ b/fetcher/debian/debian.go
@@ -20,10 +20,9 @@ func newFetchRequests(target []string) (reqs []util.FetchRequest) {
 			continue
 		}
 		reqs = append(reqs, util.FetchRequest{
-			Target:       v,
-			URL:          fmt.Sprintf(t, name),
-			Concurrently: true,
-			MIMEType:     util.MIMETypeBzip2,
+			Target:   v,
+			URL:      fmt.Sprintf(t, name),
+			MIMEType: util.MIMETypeBzip2,
 		})
 	}
 	return

--- a/fetcher/fedora/fedora.go
+++ b/fetcher/fedora/fedora.go
@@ -97,16 +97,14 @@ func newFedoraFetchRequests(target []string, arch string) (reqs []util.FetchRequ
 		}
 
 		reqs = append(reqs, util.FetchRequest{
-			Target:       v,
-			URL:          fmt.Sprintf(updateURL, v, arch),
-			MIMEType:     util.MIMETypeXML,
-			Concurrently: true,
+			Target:   v,
+			URL:      fmt.Sprintf(updateURL, v, arch),
+			MIMEType: util.MIMETypeXML,
 		})
 		moduleReqs = append(moduleReqs, util.FetchRequest{
-			Target:       v,
-			URL:          fmt.Sprintf(moduleURL, v, arch),
-			MIMEType:     util.MIMETypeXML,
-			Concurrently: true,
+			Target:   v,
+			URL:      fmt.Sprintf(moduleURL, v, arch),
+			MIMEType: util.MIMETypeXML,
 		})
 	}
 	return
@@ -350,7 +348,6 @@ func fetchCveIDsFromBugzilla(id string) ([]string, error) {
 	for i, v := range b.Blocked {
 		reqs[i] = util.FetchRequest{
 			URL:           fmt.Sprintf(bugZillaURL, v),
-			Concurrently:  true,
 			LogSuppressed: true,
 			MIMEType:      util.MIMETypeXML,
 		}
@@ -395,10 +392,9 @@ func extractInfoFromRepoMd(results []util.FetchResult, rt string, mt util.MIMETy
 			}
 			u.Path = strings.Replace(u.Path, "repodata/repomd.xml", repo.Location.Href, 1)
 			req := util.FetchRequest{
-				URL:          u.String(),
-				Target:       r.Target,
-				MIMEType:     mt,
-				Concurrently: true,
+				URL:      u.String(),
+				Target:   r.Target,
+				MIMEType: mt,
 			}
 			updateInfoReqs = append(updateInfoReqs, req)
 			break

--- a/fetcher/suse/suse.go
+++ b/fetcher/suse/suse.go
@@ -8,12 +8,12 @@ import (
 	"github.com/vulsio/goval-dictionary/fetcher/util"
 )
 
-// https://ftp.suse.com/pub/projects/security/oval/opensuse.leap.42.2.xml
-// https://ftp.suse.com/pub/projects/security/oval/opensuse.13.2.xml
-// https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.12.xml"
-// https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.12.xml
+// https://ftp.suse.com/pub/projects/security/oval/opensuse.leap.42.2.xml.gz
+// https://ftp.suse.com/pub/projects/security/oval/opensuse.13.2.xml.gz
+// https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.desktop.12.xml.gz
+// https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.server.12.xml.gz
 func newFetchRequests(suseType string, target []string) (reqs []util.FetchRequest) {
-	const t = "https://ftp.suse.com/pub/projects/security/oval/%s.%s.xml"
+	const t = "https://ftp.suse.com/pub/projects/security/oval/%s.%s.xml.gz"
 	for _, v := range target {
 		reqs = append(reqs, util.FetchRequest{
 			Target:   v,

--- a/fetcher/suse/suse.go
+++ b/fetcher/suse/suse.go
@@ -16,10 +16,9 @@ func newFetchRequests(suseType string, target []string) (reqs []util.FetchReques
 	const t = "https://ftp.suse.com/pub/projects/security/oval/%s.%s.xml"
 	for _, v := range target {
 		reqs = append(reqs, util.FetchRequest{
-			Target:       v,
-			URL:          fmt.Sprintf(t, suseType, v),
-			Concurrently: true,
-			MIMEType:     util.MIMETypeXML,
+			Target:   v,
+			URL:      fmt.Sprintf(t, suseType, v),
+			MIMEType: util.MIMETypeGzip,
 		})
 	}
 	return

--- a/fetcher/ubuntu/ubuntu.go
+++ b/fetcher/ubuntu/ubuntu.go
@@ -21,10 +21,9 @@ func newFetchRequests(target []string) (reqs []util.FetchRequest) {
 			log15.Warn("See https://wiki.ubuntu.com/Releases for supported versions")
 		default:
 			reqs = append(reqs, util.FetchRequest{
-				Target:       v,
-				URL:          url,
-				Concurrently: true,
-				MIMEType:     util.MIMETypeBzip2,
+				Target:   v,
+				URL:      url,
+				MIMEType: util.MIMETypeBzip2,
 			})
 		}
 	}

--- a/fetcher/util/fetcher.go
+++ b/fetcher/util/fetcher.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/htcat/htcat"
 	"github.com/inconshreveable/log15"
 	"github.com/spf13/viper"
 	"github.com/ulikunitz/xz"
@@ -68,7 +67,6 @@ type FetchRequest struct {
 	Target        string
 	URL           string
 	MIMEType      MIMEType
-	Concurrently  bool
 	LogSuppressed bool
 }
 
@@ -122,12 +120,7 @@ func FetchFeedFiles(reqs []FetchRequest) (results []FetchResult, err error) {
 		tasks <- func() {
 			select {
 			case req := <-reqChan:
-				var body []byte
-				if req.Concurrently {
-					body, err = fetchFileConcurrently(req, 20/len(reqs))
-				} else {
-					body, err = fetchFileWithUA(req)
-				}
+				body, err := fetchFileWithUA(req)
 				wg.Done()
 				if err != nil {
 					errChan <- err
@@ -161,57 +154,6 @@ func FetchFeedFiles(reqs []FetchRequest) (results []FetchResult, err error) {
 		return results, fmt.Errorf("%s", errs)
 	}
 	return results, nil
-}
-
-func fetchFileConcurrently(req FetchRequest, concurrency int) (body []byte, err error) {
-	var proxyURL *url.URL
-	httpClient := &http.Client{}
-	httpProxy := viper.GetString("http-proxy")
-	if httpProxy != "" {
-		if proxyURL, err = url.Parse(httpProxy); err != nil {
-			return nil, xerrors.Errorf("Failed to parse proxy url. err: %w", err)
-		}
-		httpClient = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
-	}
-
-	u, err := url.Parse(req.URL)
-	if err != nil {
-		return nil, xerrors.Errorf("Failed to parse given URL: %w", err)
-	}
-
-	buf := bytes.Buffer{}
-	htc := htcat.New(httpClient, u, concurrency)
-	if _, err := htc.WriteTo(&buf); err != nil {
-		return nil, xerrors.Errorf("Failed to write to output stream: %w", err)
-	}
-
-	var b bytes.Buffer
-	switch req.MIMEType {
-	case MIMETypeXML, MIMETypeTxt, MIMETypeJSON, MIMETypeYml, MIMETypeHTML:
-		b = buf
-	case MIMETypeBzip2:
-		if _, err := b.ReadFrom(bzip2.NewReader(bytes.NewReader(buf.Bytes()))); err != nil {
-			return nil, xerrors.Errorf("Failed to open bzip2 file. err: %w", err)
-		}
-	case MIMETypeXz:
-		r, err := xz.NewReader(bytes.NewReader(buf.Bytes()))
-		if err != nil {
-			return nil, xerrors.Errorf("Failed to open xz file. err: %w", err)
-		}
-		if _, err := b.ReadFrom(r); err != nil {
-			return nil, xerrors.Errorf("Failed to read xz file. err: %w", err)
-		}
-	case MIMETypeGzip:
-		r, err := gzip.NewReader(bytes.NewReader(buf.Bytes()))
-		if err != nil {
-			return nil, xerrors.Errorf("Failed to open gzip file. err: %w", err)
-		}
-		if _, err := b.ReadFrom(r); err != nil {
-			return nil, xerrors.Errorf("Failed to read gzip file. err: %w", err)
-		}
-	}
-
-	return b.Bytes(), nil
 }
 
 func fetchFileWithUA(req FetchRequest) (body []byte, err error) {

--- a/fetcher/util/fetcher.go
+++ b/fetcher/util/fetcher.go
@@ -15,6 +15,8 @@ import (
 	"github.com/spf13/viper"
 	"github.com/ulikunitz/xz"
 	"golang.org/x/xerrors"
+
+	"github.com/vulsio/goval-dictionary/config"
 )
 
 // MIMEType :
@@ -174,7 +176,7 @@ func fetchFileWithUA(req FetchRequest) (body []byte, err error) {
 		return nil, xerrors.Errorf("Failed to download. err: %w", err)
 	}
 
-	httpreq.Header.Set("User-Agent", "curl/7.37.0")
+	httpreq.Header.Set("User-Agent", fmt.Sprintf("goval-dictionary/%s.%s", config.Version, config.Revision))
 	resp, err = httpClient.Do(httpreq)
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to download. err: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-version v1.6.0
-	github.com/htcat/htcat v1.0.2
 	github.com/inconshreveable/log15 v3.0.0-testing.5+incompatible
 	github.com/k0kubun/pp v3.0.1+incompatible
 	github.com/knqyf263/go-rpm-version v0.0.0-20220614171824-631e686d1075

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/htcat/htcat v1.0.2 h1:zro95dGwkKDeZOgq9ei+9szd5qurGxBGfHY8hRehA7k=
-github.com/htcat/htcat v1.0.2/go.mod h1:i8ViQbjSi2+lJzM6Lx20FIxHENCz6mzJglK3HH06W3s=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/log15 v3.0.0-testing.5+incompatible h1:VryeOTiaZfAzwx8xBcID1KlJCeoWSIpsNbSk+/D2LNk=


### PR DESCRIPTION
# What did you implement:

I think htcat is not necessary to fetch compressed OVAL or non-large files.

Also, I set up a User-Agent that can be recognized as goval-dictionary.
Fixes #336 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

# Checklist:
- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

