### PR TITLE
fix(ubuntu) delete 19.10 and 20.10 from document because unsupported

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -106,7 +106,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      Version: 14.04 16.04 18.04 19.10 20.04 20.10 21.04 21.10 22.04 22.10 23.04
+      Version: 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -91,7 +91,7 @@ clean-integration:
 
 fetch-rdb:
 	integration/goval-dict.old fetch debian --dbpath=$(PWD)/integration/oval.old.sqlite3 7 8 9 10 11
-	integration/goval-dict.old fetch ubuntu --dbpath=$(PWD)/integration/oval.old.sqlite3 14.04 16.04 18.04 19.10 20.04 20.10 21.04 21.10 22.04 22.10 23.04
+	integration/goval-dict.old fetch ubuntu --dbpath=$(PWD)/integration/oval.old.sqlite3 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
 	integration/goval-dict.old fetch redhat --dbpath=$(PWD)/integration/oval.old.sqlite3 5 6 7 8 9
 	integration/goval-dict.old fetch oracle --dbpath=$(PWD)/integration/oval.old.sqlite3 5 6 7 8 9
 	integration/goval-dict.old fetch amazon --dbpath=$(PWD)/integration/oval.old.sqlite3 1 2 2022 2023
@@ -103,7 +103,7 @@ fetch-rdb:
 	integration/goval-dict.old fetch fedora --dbpath=$(PWD)/integration/oval.old.sqlite3 32 33 34 35
 
 	integration/goval-dict.new fetch debian --dbpath=$(PWD)/integration/oval.new.sqlite3 7 8 9 10 11
-	integration/goval-dict.new fetch ubuntu --dbpath=$(PWD)/integration/oval.new.sqlite3 14.04 16.04 18.04 19.10 20.04 20.10 21.04 21.10 22.04 22.10 23.04
+	integration/goval-dict.new fetch ubuntu --dbpath=$(PWD)/integration/oval.new.sqlite3 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
 	integration/goval-dict.new fetch redhat --dbpath=$(PWD)/integration/oval.new.sqlite3 5 6 7 8 9
 	integration/goval-dict.new fetch oracle --dbpath=$(PWD)/integration/oval.new.sqlite3 5 6 7 8 9
 	integration/goval-dict.new fetch amazon --dbpath=$(PWD)/integration/oval.new.sqlite3 1 2 2022 2023
@@ -119,7 +119,7 @@ fetch-redis:
 	docker run --name redis-new -d -p 127.0.0.1:6380:6379 redis
 
 	integration/goval-dict.old fetch debian --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 7 8 9 10 11
-	integration/goval-dict.old fetch ubuntu --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 14.04 16.04 18.04 19.10 20.04 20.10 21.04 21.10 22.04 22.10 23.04
+	integration/goval-dict.old fetch ubuntu --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
 	integration/goval-dict.old fetch redhat --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 5 6 7 8 9
 	integration/goval-dict.old fetch oracle --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 5 6 7 8 9
 	integration/goval-dict.old fetch amazon --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 1 2 2022 2023
@@ -131,7 +131,7 @@ fetch-redis:
 	integration/goval-dict.old fetch fedora --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 32 33 34 35
 
 	integration/goval-dict.new fetch debian --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 7 8 9 10 11
-	integration/goval-dict.new fetch ubuntu --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 14.04 16.04 18.04 19.10 20.04 20.10 21.04 21.10 22.04 22.10 23.04
+	integration/goval-dict.new fetch ubuntu --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
 	integration/goval-dict.new fetch redhat --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 5 6 7 8 9
 	integration/goval-dict.new fetch oracle --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 5 6 7 8 9
 	integration/goval-dict.new fetch amazon --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 1 2 2022 2023
@@ -144,7 +144,7 @@ fetch-redis:
 
 diff-cveid:
 	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid debian 7 8 9 10 11
-	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid ubuntu 14.04 16.04 18.04 19.10 20.04 20.10 21.04 21.10 22.04 22.10 23.04
+	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid ubuntu 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
 	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid redhat 5 6 7 8 9
 	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid oracle 5 6 7 8 9
 	@ python integration/diff_server_mode.py --sample-rate 0.01 --arch x86_64 cveid oracle 5 6 7 8 9
@@ -161,7 +161,7 @@ diff-cveid:
 
 diff-package:
 	@ python integration/diff_server_mode.py --sample-rate 0.01 package debian 7 8 9 10 11
-	@ python integration/diff_server_mode.py --sample-rate 0.01 package ubuntu 14.04 16.04 18.04 19.10 20.04 20.10 21.04 21.10 22.04 22.10 23.04
+	@ python integration/diff_server_mode.py --sample-rate 0.01 package ubuntu 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
 	@ python integration/diff_server_mode.py --sample-rate 0.01 package redhat 5 6 7 8 9
 	@ python integration/diff_server_mode.py --sample-rate 0.01 package oracle 5 6 7 8 9
 	@ python integration/diff_server_mode.py --sample-rate 0.01 --arch x86_64 package oracle 5 6 7 8 9

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ $ goval-dictionary fetch debian 7 8 9 10 11
 - [Ubuntu(main)](https://security-metadata.canonical.com/oval/)
 - [Ubuntu(sub)](https://people.canonical.com/~ubuntu-security/oval/)
 ```bash
-$ goval-dictionary fetch ubuntu 14.04 16.04 18.04 19.10 20.04 20.10 21.04 21.10 22.04 22.10 23.04
+$ goval-dictionary fetch ubuntu 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
 ```
 
 #### Usage: Fetch OVAL data from SUSE

--- a/config/config.go
+++ b/config/config.go
@@ -31,14 +31,8 @@ const (
 	// Ubuntu1804 is Ubuntu Bionic
 	Ubuntu1804 = "bionic"
 
-	// Ubuntu1910 is Eoan Ermine
-	Ubuntu1910 = "eoan"
-
 	// Ubuntu2004 is Focal Fossa
 	Ubuntu2004 = "focal"
-
-	// Ubuntu2010 is Groovy Gorilla
-	Ubuntu2010 = "groovy"
 
 	// Ubuntu2104 is Hirsute Hippo
 	Ubuntu2104 = "hirsute"


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

delete 19.10 and 20.10 from document because unsupported

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

