### PR TITLE
feat(ubuntu): add 23.10 (mantic minotaur)

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -106,7 +106,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      Version: 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
+      Version: 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04 23.10
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -91,7 +91,7 @@ clean-integration:
 
 fetch-rdb:
 	integration/goval-dict.old fetch debian --dbpath=$(PWD)/integration/oval.old.sqlite3 7 8 9 10 11
-	integration/goval-dict.old fetch ubuntu --dbpath=$(PWD)/integration/oval.old.sqlite3 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
+	integration/goval-dict.old fetch ubuntu --dbpath=$(PWD)/integration/oval.old.sqlite3 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04 23.10
 	integration/goval-dict.old fetch redhat --dbpath=$(PWD)/integration/oval.old.sqlite3 5 6 7 8 9
 	integration/goval-dict.old fetch oracle --dbpath=$(PWD)/integration/oval.old.sqlite3 5 6 7 8 9
 	integration/goval-dict.old fetch amazon --dbpath=$(PWD)/integration/oval.old.sqlite3 1 2 2022 2023
@@ -103,7 +103,7 @@ fetch-rdb:
 	integration/goval-dict.old fetch fedora --dbpath=$(PWD)/integration/oval.old.sqlite3 32 33 34 35
 
 	integration/goval-dict.new fetch debian --dbpath=$(PWD)/integration/oval.new.sqlite3 7 8 9 10 11
-	integration/goval-dict.new fetch ubuntu --dbpath=$(PWD)/integration/oval.new.sqlite3 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
+	integration/goval-dict.new fetch ubuntu --dbpath=$(PWD)/integration/oval.new.sqlite3 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04 23.10
 	integration/goval-dict.new fetch redhat --dbpath=$(PWD)/integration/oval.new.sqlite3 5 6 7 8 9
 	integration/goval-dict.new fetch oracle --dbpath=$(PWD)/integration/oval.new.sqlite3 5 6 7 8 9
 	integration/goval-dict.new fetch amazon --dbpath=$(PWD)/integration/oval.new.sqlite3 1 2 2022 2023
@@ -119,7 +119,7 @@ fetch-redis:
 	docker run --name redis-new -d -p 127.0.0.1:6380:6379 redis
 
 	integration/goval-dict.old fetch debian --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 7 8 9 10 11
-	integration/goval-dict.old fetch ubuntu --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
+	integration/goval-dict.old fetch ubuntu --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04 23.10
 	integration/goval-dict.old fetch redhat --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 5 6 7 8 9
 	integration/goval-dict.old fetch oracle --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 5 6 7 8 9
 	integration/goval-dict.old fetch amazon --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 1 2 2022 2023
@@ -131,7 +131,7 @@ fetch-redis:
 	integration/goval-dict.old fetch fedora --dbtype redis --dbpath "redis://127.0.0.1:6379/0" 32 33 34 35
 
 	integration/goval-dict.new fetch debian --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 7 8 9 10 11
-	integration/goval-dict.new fetch ubuntu --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
+	integration/goval-dict.new fetch ubuntu --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04 23.10
 	integration/goval-dict.new fetch redhat --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 5 6 7 8 9
 	integration/goval-dict.new fetch oracle --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 5 6 7 8 9
 	integration/goval-dict.new fetch amazon --dbtype redis --dbpath "redis://127.0.0.1:6380/0" 1 2 2022 2023
@@ -144,7 +144,7 @@ fetch-redis:
 
 diff-cveid:
 	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid debian 7 8 9 10 11
-	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid ubuntu 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
+	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid ubuntu 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04 23.10
 	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid redhat 5 6 7 8 9
 	@ python integration/diff_server_mode.py --sample-rate 0.01 cveid oracle 5 6 7 8 9
 	@ python integration/diff_server_mode.py --sample-rate 0.01 --arch x86_64 cveid oracle 5 6 7 8 9
@@ -161,7 +161,7 @@ diff-cveid:
 
 diff-package:
 	@ python integration/diff_server_mode.py --sample-rate 0.01 package debian 7 8 9 10 11
-	@ python integration/diff_server_mode.py --sample-rate 0.01 package ubuntu 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
+	@ python integration/diff_server_mode.py --sample-rate 0.01 package ubuntu 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04 23.10
 	@ python integration/diff_server_mode.py --sample-rate 0.01 package redhat 5 6 7 8 9
 	@ python integration/diff_server_mode.py --sample-rate 0.01 package oracle 5 6 7 8 9
 	@ python integration/diff_server_mode.py --sample-rate 0.01 --arch x86_64 package oracle 5 6 7 8 9

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ $ goval-dictionary fetch debian 7 8 9 10 11
 - [Ubuntu(main)](https://security-metadata.canonical.com/oval/)
 - [Ubuntu(sub)](https://people.canonical.com/~ubuntu-security/oval/)
 ```bash
-$ goval-dictionary fetch ubuntu 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04
+$ goval-dictionary fetch ubuntu 14.04 16.04 18.04 20.04 21.04 21.10 22.04 22.10 23.04 23.10
 ```
 
 #### Usage: Fetch OVAL data from SUSE

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,9 @@ const (
 	// Ubuntu2304 is Lunar Lobster
 	Ubuntu2304 = "lunar"
 
+	// Ubuntu2310 is Mantic Minotaur
+	Ubuntu2310 = "mantic"
+
 	// Debian7 is wheezy
 	Debian7 = "wheezy"
 

--- a/fetcher/ubuntu/ubuntu.go
+++ b/fetcher/ubuntu/ubuntu.go
@@ -103,7 +103,7 @@ func getOVALURL(version string) string {
 		case "04":
 			return fmt.Sprintf(main, config.Ubuntu2304)
 		case "10":
-			return "unsupported"
+			return fmt.Sprintf(main, config.Ubuntu2310)
 		default:
 			return "unknown"
 		}

--- a/integration/diff_server_mode.py
+++ b/integration/diff_server_mode.py
@@ -126,7 +126,7 @@ if args.ostype == 'debian':
             f'Failed to diff_response..., err: This Release Version({args.release}) does not support test mode')
         raise NotImplementedError
 elif args.ostype == 'ubuntu':
-    if len(list(set(args.release) - set(['14.04', '16.04', '18.04', '19.10', '20.04', '20.10', '21.04', '21.10', '22.04', '22.10', '23.04']))) > 0:
+    if len(list(set(args.release) - set(['14.04', '16.04', '18.04', '19.10', '20.04', '20.10', '21.04', '21.10', '22.04', '22.10', '23.04', '23.10']))) > 0:
         logger.error(
             f'Failed to diff_response..., err: This Release Version({args.release}) does not support test mode')
         raise NotImplementedError


### PR DESCRIPTION
# What did you implement:

add 23.10 (mantic minotaur)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

```console
$ goval-dictionary fetch ubuntu 23.10
INFO[10-20|15:01:37] Fetching...                              URL=https://security-metadata.canonical.com/oval/oci.com.ubuntu.mantic.cve.oval.xml.bz2
INFO[10-20|15:01:41] Fetched                                  File=oci.com.ubuntu.mantic.cve.oval.xml.bz2 Count=10430 Timestamp=2023-10-19T15:09:48
INFO[10-20|15:01:41] Refreshing...                            Family=ubuntu Version=23.10
INFO[10-20|15:01:41] Inserting new Definitions... 
10430 / 10430 [----------------------------------------------] 100.00% 40121 p/s
INFO[10-20|15:01:41] Finish                                   Updated=10430

$ goval-dictionary select --by-package ubuntu 23.10 curl
CVE-2023-28321
    {3744 9538 curl 7.88.1-10ubuntu1  false }
CVE-2023-28322
    {3745 9539 curl 7.88.1-10ubuntu1  false }
CVE-2023-38039
    {4387 9998 curl 8.2.1-1ubuntu3  false }
CVE-2023-38545
    {4464 10031 curl 8.2.1-1ubuntu3.1  false }
CVE-2023-38546
    {4465 10032 curl 8.2.1-1ubuntu3.1  false }
------------------
[]models.Definition{
  models.Definition{
    ID:           0x2542,
    RootID:       0x1,
    DefinitionID: "oval:com.ubuntu.mantic:def:2023283210000000",
    Title:        "CVE-2023-28321 on Ubuntu 23.10 (mantic) - low.",
    Description:  "An improper certificate validation vulnerability exists in curl <v8.1.0 in the way it supports matching of wildcard patterns when listed as \"Subject Alternative Name\" in TLS server certificates. curl can be built to use its own name matching function for TLS rather than one provided by a TLS library. This private wildcard matching function would match IDN (International Domain Name) hosts incorrectly and could as a result accept patterns that otherwise should mismatch. IDN hostnames are converted to puny code before used for certificate checks. Puny coded names always start with `xn--` and should not be allowed to pattern match, but the wildcard check in curl could still check for `x*`, which would match even though the IDN name most likely contained nothing even resembling an `x`.\n\nUpdate Instructions:\n\nRun `sudo pro fix CVE-2023-28321` to fix the vulnerability. The problem can be corrected\nby updating your system to the following package versions:\n\ncurl - 7.88.1-10ubuntu1\nlibcurl3-gnutls - 7.88.1-10ubuntu1\nlibcurl3-nss - 7.88.1-10ubuntu1\nlibcurl4 - 7.88.1-10ubuntu1\nNo subscription required",
    Advisory:     models.Advisory{
      ID:           0x2542,
      DefinitionID: 0x2542,
      Severity:     "Low",
      Cves:         []models.Cve{
        models.Cve{
          ID:         0x2542,
          AdvisoryID: 0x2542,
          CveID:      "CVE-2023-28321",
          Cvss2:      "",
          Cvss3:      "",
          Cwe:        "",
          Impact:     "",
          Href:       "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28321",
          Public:     "",
        },
      },
      Bugzillas:          []models.Bugzilla{},
      AffectedCPEList:    []models.Cpe{},
      AffectedRepository: "",
      Issued:             2023-05-17 06:00:00 UTC,
      Updated:            2023-05-17 06:00:00 UTC,
    },
    Debian:        (*models.Debian)(nil),
    AffectedPacks: []models.Package{
      models.Package{
        ID:              0xea0,
        DefinitionID:    0x2542,
        Name:            "curl",
        Version:         "7.88.1-10ubuntu1",
        Arch:            "",
        NotFixedYet:     false,
        ModularityLabel: "",
      },
    },
    References: []models.Reference{
      models.Reference{
        ID:           0x31c4,
        DefinitionID: 0x2542,
        Source:       "CVE",
        RefID:        "CVE-2023-28321",
        RefURL:       "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28321",
      },
    },
  },
...
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

