### PR TITLE
fix(fetcher/fedora): ignore errors with missing modular updateinfo

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -354,7 +354,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      Version: 32 33 34 35 36 37 38
+      Version: 32 33 34 35 36 37 38 39
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -664,7 +664,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      Version: 3.2 3.3 3.4 3.5 3.6 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14 3.15 3.16 3.17
+      Version: 3.2 3.3 3.4 3.5 3.6 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14 3.15 3.16 3.17 3.18 3.19
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/fetcher/fedora/types.go
+++ b/fetcher/fedora/types.go
@@ -104,3 +104,26 @@ func (r Rpm) NewPackageFromRpm() (models.Package, error) {
 	}
 	return pkg, nil
 }
+
+// uniquePackages returns deduplicated []Package by Filename
+// If Filename is the same, all other information is considered to be the same
+func uniquePackages(pkgs []models.Package) []models.Package {
+	tmp := make(map[string]models.Package)
+	ret := []models.Package{}
+	for _, pkg := range pkgs {
+		tmp[pkg.Filename] = pkg
+	}
+	for _, v := range tmp {
+		ret = append(ret, v)
+	}
+	return ret
+}
+
+func mergeUpdates(source map[string]*models.Updates, target map[string]*models.Updates) map[string]*models.Updates {
+	for osVer, sourceUpdates := range source {
+		if targetUpdates, ok := target[osVer]; ok {
+			source[osVer].UpdateList = append(sourceUpdates.UpdateList, targetUpdates.UpdateList...)
+		}
+	}
+	return source
+}

--- a/fetcher/fedora/types_test.go
+++ b/fetcher/fedora/types_test.go
@@ -218,6 +218,28 @@ func TestUpdatesPerVersionMerge(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "target is nil",
+			source: map[string]*models.Updates{
+				"39": {
+					UpdateList: []models.UpdateInfo{
+						{
+							Title: "update39",
+						},
+					},
+				},
+			},
+			target: nil,
+			want: map[string]*models.Updates{
+				"39": {
+					UpdateList: []models.UpdateInfo{
+						{
+							Title: "update39",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# What did you implement:

In fedora 39 Modular, an error occurs because updateinfo is not provided. 
However, if there are no package updates, updateinfo may not be provided, so ignore errors when updateinfo is not provided, especially in the case of modular.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ goval-dictionary fetch fedora 39
INFO[02-21|00:37:14] start fetch data from repomd.xml of non-modular package 
INFO[02-21|00:37:14] Fetching...                              URL=https://dl.fedoraproject.org/pub/fedora/linux/updates/39/Everything/x86_64/repodata/repomd.xml
INFO[02-21|00:37:15] start fetch updateinfo in repomd.xml 
INFO[02-21|00:37:15] Fetching...                              URL=https://dl.fedoraproject.org/pub/fedora/linux/updates/39/Everything/x86_64/repodata/1127f254261a7d8e50363c58285ae5306032e66ce8b46f02868f810344d0392f-updateinfo.xml.xz
INFO[02-21|00:37:17] start fetch data from repomd.xml of modular 
INFO[02-21|00:37:17] Fetching...                              URL=https://dl.fedoraproject.org/pub/fedora/linux/updates/39/Modular/x86_64/repodata/repomd.xml
INFO[02-21|00:37:18] start fetch updateinfo in repomd.xml 
Failed to fetch files. err: fetchModulesFedora. err: Failed to fetch updateinfo, err: No updateinfo field in the repomd
```

## after
```console
$ goval-dictionary fetch fedora 39
INFO[02-21|00:51:27] start fetch data from repomd.xml of non-modular package 
INFO[02-21|00:51:27] Fetching...                              URL=https://dl.fedoraproject.org/pub/fedora/linux/updates/39/Everything/x86_64/repodata/repomd.xml
INFO[02-21|00:51:27] start fetch updateinfo in repomd.xml 
INFO[02-21|00:51:27] Fetching...                              URL=https://dl.fedoraproject.org/pub/fedora/linux/updates/39/Everything/x86_64/repodata/1127f254261a7d8e50363c58285ae5306032e66ce8b46f02868f810344d0392f-updateinfo.xml.xz
INFO[02-21|00:51:29] start fetch data from repomd.xml of modular 
INFO[02-21|00:51:29] Fetching...                              URL=https://dl.fedoraproject.org/pub/fedora/linux/updates/39/Modular/x86_64/repodata/repomd.xml
INFO[02-21|00:51:30] start fetch updateinfo in repomd.xml 
INFO[02-21|00:51:30] start fetch data from repomd.xml of non-modular package 
INFO[02-21|00:51:30] Fetching...                              URL=https://dl.fedoraproject.org/pub/fedora/linux/updates/39/Everything/aarch64/repodata/repomd.xml
INFO[02-21|00:51:30] start fetch updateinfo in repomd.xml 
INFO[02-21|00:51:30] Fetching...                              URL=https://dl.fedoraproject.org/pub/fedora/linux/updates/39/Everything/aarch64/repodata/1127f254261a7d8e50363c58285ae5306032e66ce8b46f02868f810344d0392f-updateinfo.xml.xz
INFO[02-21|00:51:32] start fetch data from repomd.xml of modular 
INFO[02-21|00:51:32] Fetching...                              URL=https://dl.fedoraproject.org/pub/fedora/linux/updates/39/Modular/aarch64/repodata/repomd.xml
INFO[02-21|00:51:32] start fetch updateinfo in repomd.xml 
INFO[02-21|00:51:32] 138 Advisories for Fedora 39 Fetched 
INFO[02-21|00:51:32] 138 CVEs for Fedora 39. Inserting to DB 
INFO[02-21|00:51:32] Refreshing...                            Family=fedora Version=39
INFO[02-21|00:51:32] Inserting new Definitions... 
138 / 138 [------------------------------------------------------] 100.00% ? p/s
INFO[02-21|00:51:32] Finish                                   Updated=138
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

