### PR TITLE
feat(fetcher/redhat): fetch extras, supplementary, els advisories

### DIFF
--- a/commands/fetch-redhat.go
+++ b/commands/fetch-redhat.go
@@ -85,7 +85,7 @@ func fetchRedHat(_ *cobra.Command, args []string) (err error) {
 		}
 
 		roots := make([]redhat.Root, 0, len(m))
-		for _, k := range []string{fmt.Sprintf("rhel-%s.oval.xml.bz2", v), fmt.Sprintf("com.redhat.rhsa-RHEL%s.xml", v)} {
+		for _, k := range []string{fmt.Sprintf("rhel-%s.oval.xml.bz2", v), fmt.Sprintf("rhel-%s-extras.oval.xml.bz2", v), fmt.Sprintf("rhel-%s-supplementary.oval.xml.bz2", v), fmt.Sprintf("rhel-%s-els.oval.xml.bz2", v), fmt.Sprintf("com.redhat.rhsa-RHEL%s.xml", v), fmt.Sprintf("com.redhat.rhsa-RHEL%s-ELS.xml", v)} {
 			roots = append(roots, m[k])
 		}
 

--- a/fetcher/redhat/redhat.go
+++ b/fetcher/redhat/redhat.go
@@ -19,40 +19,96 @@ import (
 // FetchFiles fetch OVAL from RedHat
 func FetchFiles(versions []string) (map[string][]util.FetchResult, error) {
 	results := map[string][]util.FetchResult{}
-	vs := make([]string, 0, len(versions))
 	for _, v := range versions {
-		n, err := strconv.Atoi(v)
-		if err != nil {
-			log15.Warn("Skip unknown redhat.", "version", v)
-			continue
-		}
-
-		if n < 5 {
+		switch v {
+		case "1", "2", "3":
 			log15.Warn("Skip redhat because no vulnerability information provided.", "version", v)
-			continue
-		}
+		case "4":
+			rs, err := fetchOVALv1([]string{fmt.Sprintf("com.redhat.rhsa-RHEL%s.xml", v)})
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to fetch OVALv1. err: %w", err)
+			}
+			results[v] = rs
+		case "5":
+			rs, err := fetchOVALv1([]string{fmt.Sprintf("com.redhat.rhsa-RHEL%s.xml", v), fmt.Sprintf("com.redhat.rhsa-RHEL%s-ELS.xml", v)})
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to fetch OVALv1. err: %w", err)
+			}
+			results[v] = rs
+		case "6":
+			rs, err := fetchOVALv1([]string{fmt.Sprintf("com.redhat.rhsa-RHEL%s.xml", v)})
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to fetch OVALv1. err: %w", err)
+			}
+			results[v] = rs
 
-		vs = append(vs, v)
+			rs, err = fetchOVALv2([]string{v, fmt.Sprintf("%s-extras", v), fmt.Sprintf("%s-supplementary", v), fmt.Sprintf("%s-els", v)})
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to fetch OVALv2. err: %w", err)
+			}
+			results[v] = append(results[v], rs...)
+		case "7":
+			rs, err := fetchOVALv1([]string{fmt.Sprintf("com.redhat.rhsa-RHEL%s.xml", v)})
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to fetch OVALv1. err: %w", err)
+			}
+			results[v] = rs
+
+			rs, err = fetchOVALv2([]string{v, fmt.Sprintf("%s-extras", v), fmt.Sprintf("%s-supplementary", v)})
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to fetch OVALv2. err: %w", err)
+			}
+			results[v] = append(results[v], rs...)
+		case "8", "9":
+			rs, err := fetchOVALv1([]string{fmt.Sprintf("com.redhat.rhsa-RHEL%s.xml", v)})
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to fetch OVALv1. err: %w", err)
+			}
+			results[v] = rs
+
+			rs, err = fetchOVALv2([]string{v})
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to fetch OVALv2. err: %w", err)
+			}
+			results[v] = append(results[v], rs...)
+		default:
+			if _, err := strconv.Atoi(v); err != nil {
+				log15.Warn("Skip unknown redhat.", "version", v)
+				break
+			}
+
+			rs, err := fetchOVALv2([]string{v})
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to fetch OVALv2. err: %w", err)
+			}
+			results[v] = rs
+		}
 	}
-	if len(vs) == 0 {
+
+	if len(results) == 0 {
 		return nil, xerrors.New("There are no versions to fetch")
 	}
+	return results, nil
+}
 
+func fetchOVALv1(names []string) ([]util.FetchResult, error) {
 	log15.Info("Fetching... ", "URL", "https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz")
 	resp, err := http.Get("https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz")
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to get oval v1. err: %w", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return nil, xerrors.Errorf("Failed to get oval v1. err: bad status %d", resp.StatusCode)
 	}
-	defer resp.Body.Close()
 
 	gr, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to create gzip reader. err: %w", err)
 	}
 	defer gr.Close()
+
+	results := make([]util.FetchResult, 0, len(names))
 
 	tr := tar.NewReader(gr)
 	for {
@@ -64,42 +120,37 @@ func FetchFiles(versions []string) (map[string][]util.FetchResult, error) {
 			return nil, xerrors.Errorf("Failed to next tar reader. err: %w", err)
 		}
 
-		v := strings.TrimSuffix(strings.TrimPrefix(hdr.Name, "com.redhat.rhsa-RHEL"), ".xml")
-		if slices.Contains(vs, v) {
-			bs, err := io.ReadAll(tr)
-			if err != nil {
-				return nil, xerrors.Errorf("Failed to read all com.redhat.rhsa-RHEL%s.xml. err: %w", v, err)
-			}
-			results[v] = append(results[v], util.FetchResult{
-				Target: v,
-				URL:    fmt.Sprintf("https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz/com.redhat.rhsa-RHEL%s.xml", v),
-				Body:   bs,
-			})
+		if !slices.Contains(names, hdr.Name) {
+			continue
 		}
-	}
 
-	reqs := make([]util.FetchRequest, 0, len(vs))
-	for _, v := range vs {
-		if v != "5" {
-			reqs = append(reqs, util.FetchRequest{
-				Target:   v,
-				URL:      fmt.Sprintf("https://access.redhat.com/security/data/oval/v2/RHEL%s/rhel-%s.oval.xml.bz2", v, v),
-				MIMEType: util.MIMETypeBzip2,
-			})
-		}
-	}
-	if len(reqs) > 0 {
-		rs, err := util.FetchFeedFiles(reqs)
+		bs, err := io.ReadAll(tr)
 		if err != nil {
-			return nil, xerrors.Errorf("Failed to fetch. err: %w", err)
+			return nil, xerrors.Errorf("Failed to read all %s. err: %w", hdr.Name, err)
 		}
-		for _, r := range rs {
-			results[r.Target] = append(results[r.Target], r)
-		}
+		results = append(results, util.FetchResult{
+			Target: strings.TrimSuffix(strings.TrimPrefix(hdr.Name, "com.redhat.rhsa-RHEL"), ".xml"),
+			URL:    fmt.Sprintf("https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz/%s", hdr.Name),
+			Body:   bs,
+		})
 	}
 
-	if len(results) == 0 {
-		return nil, xerrors.New("There are no versions to fetch")
-	}
 	return results, nil
+}
+
+func fetchOVALv2(names []string) ([]util.FetchResult, error) {
+	reqs := make([]util.FetchRequest, 0, len(names))
+	for _, n := range names {
+		reqs = append(reqs, util.FetchRequest{
+			Target:   n,
+			URL:      fmt.Sprintf("https://access.redhat.com/security/data/oval/v2/RHEL%s/rhel-%s.oval.xml.bz2", strings.Split(n, "-")[0], n),
+			MIMEType: util.MIMETypeBzip2,
+		})
+	}
+
+	rs, err := util.FetchFeedFiles(reqs)
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to fetch. err: %w", err)
+	}
+	return rs, nil
 }


### PR DESCRIPTION
# What did you implement:

fetch extras, supplementary, els advisories.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## before
```console
$ goval-dictionary fetch redhat 6
$ goval-dictionary.master select --by-cveid redhat 6 CVE-2023-46847
------------------
[]models.Definition{}
```

## after
```console
$ goval-dictionary fetch redhat 6
$ goval-dictionary.pr select --by-cveid redhat 6 CVE-2023-46847
RHSA-2023:6882: squid34 security update (Critical)
[{10917 1839 CVE-2023-46847  8.6/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H CWE-120 critical https://access.redhat.com/security/cve/CVE-2023-46847 20231019}]
RHSA-2023:6884: squid security update (Critical)
[{17170 2889 CVE-2023-46847  8.6/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H CWE-120 critical https://access.redhat.com/security/cve/CVE-2023-46847 20231019}]
------------------
[]models.Definition{
  models.Definition{
    ID:           0x72f,
    RootID:       0x2,
    DefinitionID: "oval:com.redhat.rhsa:def:20236882",
    Title:        "RHSA-2023:6882: squid34 security update (Critical)",
    Description:  "The \"squid34\" packages provide version 3.4 of Squid, a high-performance proxy caching server for web clients, supporting FTP, Gopher, and HTTP data objects. Note that apart from \"squid34\", this version of Red Hat Enterprise Linux also includes the \"squid\" packages which provide Squid version 3.1.\n\nSecurity Fix(es):\n\n* squid: Denial of Service in HTTP Digest Authentication (CVE-2023-46847)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
    Advisory:     models.Advisory{
      ID:           0x72f,
      DefinitionID: 0x72f,
      Severity:     "Critical",
      Cves:         []models.Cve{
        models.Cve{
          ID:         0x2aa5,
          AdvisoryID: 0x72f,
          CveID:      "CVE-2023-46847",
          Cvss2:      "",
          Cvss3:      "8.6/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H",
          Cwe:        "CWE-120",
          Impact:     "critical",
          Href:       "https://access.redhat.com/security/cve/CVE-2023-46847",
          Public:     "20231019",
        },
      },
      Bugzillas: []models.Bugzilla{
        models.Bugzilla{
          ID:         0x252a,
          AdvisoryID: 0x72f,
          BugzillaID: "2245916",
          URL:        "https://bugzilla.redhat.com/2245916",
          Title:      "squid: Denial of Service in HTTP Digest Authentication",
        },
      },
      AffectedCPEList: []models.Cpe{
        models.Cpe{
          ID:         0x44de,
          AdvisoryID: 0x72f,
          Cpe:        "cpe:/a:redhat:rhel_extras:6",
        },
        models.Cpe{
          ID:         0x44df,
          AdvisoryID: 0x72f,
          Cpe:        "cpe:/a:redhat:rhel_extras_hpn:6",
        },
        models.Cpe{
          ID:         0x44e0,
          AdvisoryID: 0x72f,
          Cpe:        "cpe:/a:redhat:rhel_extras_oracle_java:6",
        },
        models.Cpe{
          ID:         0x44e1,
          AdvisoryID: 0x72f,
          Cpe:        "cpe:/a:redhat:rhel_extras_sap:6",
        },
        models.Cpe{
          ID:         0x44e2,
          AdvisoryID: 0x72f,
          Cpe:        "cpe:/a:redhat:rhel_extras_sap_els:6",
        },
        models.Cpe{
          ID:         0x44e3,
          AdvisoryID: 0x72f,
          Cpe:        "cpe:/a:redhat:rhel_extras_sap_hana:6",
        },
        models.Cpe{
          ID:         0x44e4,
          AdvisoryID: 0x72f,
          Cpe:        "cpe:/a:redhat:rhel_extras_sap_hana_els:6",
        },
        models.Cpe{
          ID:         0x44e5,
          AdvisoryID: 0x72f,
          Cpe:        "cpe:/o:redhat:enterprise_linux:6",
        },
        models.Cpe{
          ID:         0x44e6,
          AdvisoryID: 0x72f,
          Cpe:        "cpe:/o:redhat:enterprise_linux:6::client",
        },
        models.Cpe{
          ID:         0x44e7,
          AdvisoryID: 0x72f,
          Cpe:        "cpe:/o:redhat:enterprise_linux:6::computenode",
        },
        models.Cpe{
          ID:         0x44e8,
          AdvisoryID: 0x72f,
          Cpe:        "cpe:/o:redhat:enterprise_linux:6::server",
        },
        models.Cpe{
          ID:         0x44e9,
          AdvisoryID: 0x72f,
          Cpe:        "cpe:/o:redhat:enterprise_linux:6::workstation",
        },
        models.Cpe{
          ID:         0x44ea,
          AdvisoryID: 0x72f,
          Cpe:        "cpe:/o:redhat:rhel_els:6",
        },
      },
      AffectedRepository: "",
      Issued:             2023-11-13 00:00:00 UTC,
      Updated:            2023-11-13 00:00:00 UTC,
    },
    Debian:        (*models.Debian)(nil),
    AffectedPacks: []models.Package{
      models.Package{
        ID:              0x29f1,
        DefinitionID:    0x72f,
        Name:            "squid34",
        Version:         "7:3.4.14-15.el6_10.1",
        Arch:            "",
        NotFixedYet:     false,
        ModularityLabel: "",
      },
    },
    References: []models.Reference{
      models.Reference{
        ID:           0x31d3,
        DefinitionID: 0x72f,
        Source:       "RHSA",
        RefID:        "RHSA-2023:6882",
        RefURL:       "https://access.redhat.com/errata/RHSA-2023:6882",
      },
      models.Reference{
        ID:           0x31d4,
        DefinitionID: 0x72f,
        Source:       "CVE",
        RefID:        "CVE-2023-46847",
        RefURL:       "https://access.redhat.com/security/cve/CVE-2023-46847",
      },
    },
  },
  models.Definition{
    ID:           0xb49,
    RootID:       0x2,
    DefinitionID: "oval:com.redhat.rhsa:def:20236884",
    Title:        "RHSA-2023:6884: squid security update (Critical)",
    Description:  "Squid is a high-performance proxy caching server for web clients, supporting FTP, Gopher, and HTTP data objects.\n\nSecurity Fix(es):\n\n* squid: Denial of Service in HTTP Digest Authentication (CVE-2023-46847)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
    Advisory:     models.Advisory{
      ID:           0xb49,
      DefinitionID: 0xb49,
      Severity:     "Critical",
      Cves:         []models.Cve{
        models.Cve{
          ID:         0x4312,
          AdvisoryID: 0xb49,
          CveID:      "CVE-2023-46847",
          Cvss2:      "",
          Cvss3:      "8.6/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:H",
          Cwe:        "CWE-120",
          Impact:     "critical",
          Href:       "https://access.redhat.com/security/cve/CVE-2023-46847",
          Public:     "20231019",
        },
      },
      Bugzillas: []models.Bugzilla{
        models.Bugzilla{
          ID:         0x3a40,
          AdvisoryID: 0xb49,
          BugzillaID: "2245916",
          URL:        "https://bugzilla.redhat.com/2245916",
          Title:      "squid: Denial of Service in HTTP Digest Authentication",
        },
      },
      AffectedCPEList: []models.Cpe{
        models.Cpe{
          ID:         0x6d15,
          AdvisoryID: 0xb49,
          Cpe:        "cpe:/a:redhat:rhel_extras:6",
        },
        models.Cpe{
          ID:         0x6d16,
          AdvisoryID: 0xb49,
          Cpe:        "cpe:/a:redhat:rhel_extras_hpn:6",
        },
        models.Cpe{
          ID:         0x6d17,
          AdvisoryID: 0xb49,
          Cpe:        "cpe:/a:redhat:rhel_extras_oracle_java:6",
        },
        models.Cpe{
          ID:         0x6d18,
          AdvisoryID: 0xb49,
          Cpe:        "cpe:/a:redhat:rhel_extras_sap:6",
        },
        models.Cpe{
          ID:         0x6d19,
          AdvisoryID: 0xb49,
          Cpe:        "cpe:/a:redhat:rhel_extras_sap_els:6",
        },
        models.Cpe{
          ID:         0x6d1a,
          AdvisoryID: 0xb49,
          Cpe:        "cpe:/a:redhat:rhel_extras_sap_hana:6",
        },
        models.Cpe{
          ID:         0x6d1b,
          AdvisoryID: 0xb49,
          Cpe:        "cpe:/a:redhat:rhel_extras_sap_hana_els:6",
        },
        models.Cpe{
          ID:         0x6d1c,
          AdvisoryID: 0xb49,
          Cpe:        "cpe:/o:redhat:enterprise_linux:6",
        },
        models.Cpe{
          ID:         0x6d1d,
          AdvisoryID: 0xb49,
          Cpe:        "cpe:/o:redhat:enterprise_linux:6::client",
        },
        models.Cpe{
          ID:         0x6d1e,
          AdvisoryID: 0xb49,
          Cpe:        "cpe:/o:redhat:enterprise_linux:6::computenode",
        },
        models.Cpe{
          ID:         0x6d1f,
          AdvisoryID: 0xb49,
          Cpe:        "cpe:/o:redhat:enterprise_linux:6::server",
        },
        models.Cpe{
          ID:         0x6d20,
          AdvisoryID: 0xb49,
          Cpe:        "cpe:/o:redhat:enterprise_linux:6::workstation",
        },
        models.Cpe{
          ID:         0x6d21,
          AdvisoryID: 0xb49,
          Cpe:        "cpe:/o:redhat:rhel_els:6",
        },
      },
      AffectedRepository: "",
      Issued:             2023-11-13 00:00:00 UTC,
      Updated:            2023-11-13 00:00:00 UTC,
    },
    Debian:        (*models.Debian)(nil),
    AffectedPacks: []models.Package{
      models.Package{
        ID:              0x41d3,
        DefinitionID:    0xb49,
        Name:            "squid",
        Version:         "7:3.1.23-24.el6_10.1",
        Arch:            "",
        NotFixedYet:     false,
        ModularityLabel: "",
      },
    },
    References: []models.Reference{
      models.Reference{
        ID:           0x4e5a,
        DefinitionID: 0xb49,
        Source:       "RHSA",
        RefID:        "RHSA-2023:6884",
        RefURL:       "https://access.redhat.com/errata/RHSA-2023:6884",
      },
      models.Reference{
        ID:           0x4e5b,
        DefinitionID: 0xb49,
        Source:       "CVE",
        RefID:        "CVE-2023-46847",
        RefURL:       "https://access.redhat.com/security/cve/CVE-2023-46847",
      },
    },
  },
}
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

