### PR TITLE
fix(suse): remove CVE ID suffix

### DIFF
--- a/models/suse/suse.go
+++ b/models/suse/suse.go
@@ -122,7 +122,7 @@ func parseDefinitions(xmlName string, ovalDefs Definitions, tests map[string]rpm
 		} else {
 			for _, c := range d.Advisory.Cves {
 				cves = append(cves, models.Cve{
-					CveID:  c.CveID,
+					CveID:  strings.TrimSuffix(strings.TrimSuffix(c.CveID, " at NVD"), " at SUSE"),
 					Cvss3:  c.Cvss3,
 					Impact: c.Impact,
 					Href:   c.Href,


### PR DESCRIPTION
# What did you implement:
In the CVE part of OVAL provided by SUSE, information indicating the source such as "at NVD" and "at SUSE" has been added to the part where the CVE ID is expected.
However, due to this, when you want to search by CVE ID, it does not match completely and cannot be found. Therefore, in this PR, the suffix is removed from the CVE ID part. Source can also be determined from Href.

Also, when searching by CVE ID or Package, the definitions will be duplicated, so we use the definition ID to make them unique.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## RDB(SQLite3)
### before
```console
$ goval-dictionary fetch suse --suse-type suse-enterprise-server 15
$ goval-dictionary select --by-cveid suse.linux.enterprise.server 15.3 "CVE-2021-4024"
------------------
[]models.Definition{}

$ goval-dictionary select --by-cveid suse.linux.enterprise.server 15.3 "CVE-2021-4024 at NVD"
CVE-2021-4024
[{38295 19148 CVE-2021-4024 at SUSE  4.8/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:L  moderate https://www.suse.com/security/cve/CVE-2021-4024/ } {38296 19148 CVE-2021-4024 at NVD  6.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L  moderate https://nvd.nist.gov/vuln/detail/CVE-2021-4024 }]
------------------
[]models.Definition{
  models.Definition{
...
```

### after
```console
$ goval-dictionary fetch suse --suse-type suse-enterprise-server 15
$ goval-dictionary select --by-cveid suse.linux.enterprise.server 15.3 "CVE-2021-4024"
CVE-2021-4024
[{162559 81280 CVE-2021-4024  4.8/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:L  moderate https://www.suse.com/security/cve/CVE-2021-4024/ } {162560 81280 CVE-2021-4024  6.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L  moderate https://nvd.nist.gov/vuln/detail/CVE-2021-4024 }]
------------------
[]models.Definition{
  models.Definition{
...
```

## Redis
### before
```console
$ docker run --rm -d -p 127.0.0.1:6379:6379 redis
$ goval-dictionary fetch suse --suse-type suse-enterprise-server 15 --dbtype redis --dbpath "redis://127.0.0.1:6379/1"
$ goval-dictionary select --by-cveid suse.linux.enterprise.server 15.3 "CVE-2021-4024" --dbtype redis --dbpath "redis://127.0.0.1:6379/1"
------------------
[]models.Definition{}

$ goval-dictionary select --by-cveid suse.linux.enterprise.server 15.3 "CVE-2021-4024 at NVD" --dbtype redis --dbpath "redis://127.0.0.1:6379/1"
CVE-2021-4024
[{0 0 CVE-2021-4024 at SUSE  4.8/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:L  moderate https://www.suse.com/security/cve/CVE-2021-4024/ } {0 0 CVE-2021-4024 at NVD  6.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L  moderate https://nvd.nist.gov/vuln/detail/CVE-2021-4024 }]
------------------
[]models.Definition{
  models.Definition{
...
```

### after
```console
$ docker run --rm -d -p 127.0.0.1:6379:6379 redis
$ goval-dictionary fetch suse --suse-type suse-enterprise-server 15 --dbtype redis --dbpath "redis://127.0.0.1:6379/1"
$ goval-dictionary select --by-cveid suse.linux.enterprise.server 15.3 "CVE-2021-4024" --dbtype redis --dbpath "redis://127.0.0.1:6379/1"
CVE-2021-4024
[{0 0 CVE-2021-4024  4.8/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:L  moderate https://www.suse.com/security/cve/CVE-2021-4024/ } {0 0 CVE-2021-4024  6.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L  moderate https://nvd.nist.gov/vuln/detail/CVE-2021-4024 }]
------------------
[]models.Definition{
  models.Definition{
...
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
- https://github.com/vulsio/goval-dictionary/issues/384