### PR TITLE
feat(fetch/redhat): fetch including-unpatched

### DIFF
--- a/commands/fetch-redhat.go
+++ b/commands/fetch-redhat.go
@@ -85,7 +85,7 @@ func fetchRedHat(_ *cobra.Command, args []string) (err error) {
 		}
 
 		roots := make([]redhat.Root, 0, len(m))
-		for _, k := range []string{fmt.Sprintf("rhel-%s.oval.xml.bz2", v), fmt.Sprintf("rhel-%s-extras.oval.xml.bz2", v), fmt.Sprintf("rhel-%s-supplementary.oval.xml.bz2", v), fmt.Sprintf("rhel-%s-els.oval.xml.bz2", v), fmt.Sprintf("com.redhat.rhsa-RHEL%s.xml", v), fmt.Sprintf("com.redhat.rhsa-RHEL%s-ELS.xml", v)} {
+		for _, k := range []string{fmt.Sprintf("rhel-%s-including-unpatched.oval.xml.bz2", v), fmt.Sprintf("rhel-%s-extras-including-unpatched.oval.xml.bz2", v), fmt.Sprintf("rhel-%s-supplementary.oval.xml.bz2", v), fmt.Sprintf("rhel-%s-els.oval.xml.bz2", v), fmt.Sprintf("com.redhat.rhsa-RHEL%s.xml", v), fmt.Sprintf("com.redhat.rhsa-RHEL%s-ELS.xml", v)} {
 			roots = append(roots, m[k])
 		}
 

--- a/db/db.go
+++ b/db/db.go
@@ -154,8 +154,8 @@ func chunkSlice(length int, chunkSize int) <-chan IndexChunk {
 
 func filterByRedHatMajor(packs []models.Package, majorVer string) (filtered []models.Package) {
 	for _, p := range packs {
-		if strings.Contains(p.Version, ".el"+majorVer) ||
-			strings.Contains(p.Version, ".module+el"+majorVer) {
+		if p.NotFixedYet ||
+			strings.Contains(p.Version, ".el"+majorVer) || strings.Contains(p.Version, ".module+el"+majorVer) {
 			filtered = append(filtered, p)
 		}
 	}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -373,6 +373,35 @@ func Test_filterByRedHatMajor(t *testing.T) {
 				},
 			},
 		},
+		{
+			in: args{
+				packs: []models.Package{
+					{
+						Name:    "name-el7",
+						Version: "0:0.0.1-0.0.1.el7",
+					},
+					{
+						Name:    "name-el8",
+						Version: "0:0.0.1-0.0.1.el8",
+					},
+					{
+						Name:        "notfixedyet",
+						NotFixedYet: true,
+					},
+				},
+				majorVer: "8",
+			},
+			expected: []models.Package{
+				{
+					Name:    "name-el8",
+					Version: "0:0.0.1-0.0.1.el8",
+				},
+				{
+					Name:        "notfixedyet",
+					NotFixedYet: true,
+				},
+			},
+		},
 	}
 
 	for i, tt := range tests {

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -132,6 +132,8 @@ func (r *RDBDriver) MigrateDB() error {
 		&models.Advisory{},
 		&models.Cve{},
 		&models.Bugzilla{},
+		&models.Resolution{},
+		&models.Component{},
 		&models.Cpe{},
 		&models.Debian{},
 	); err != nil {
@@ -156,9 +158,7 @@ func (r *RDBDriver) MigrateDB() error {
 				}
 			}
 		case dialectMysql, dialectPostgreSQL:
-			if err != nil {
-				return xerrors.Errorf("Failed to migrate. err: %w", err)
-			}
+			return xerrors.Errorf("Failed to migrate. err: %w", err)
 		default:
 			return xerrors.Errorf("Not Supported DB dialects. r.name: %s", r.name)
 		}
@@ -196,6 +196,8 @@ func (r *RDBDriver) GetByPackName(family, osVer, packName, arch string) ([]model
 		Preload("Advisory").
 		Preload("Advisory.Cves").
 		Preload("Advisory.Bugzillas").
+		Preload("Advisory.AffectedResolution").
+		Preload("Advisory.AffectedResolution.Components").
 		Preload("Advisory.AffectedCPEList").
 		Preload("References")
 
@@ -253,6 +255,8 @@ func (r *RDBDriver) GetByCveID(family, osVer, cveID, arch string) ([]models.Defi
 		Preload("Advisory").
 		Preload("Advisory.Cves").
 		Preload("Advisory.Bugzillas").
+		Preload("Advisory.AffectedResolution").
+		Preload("Advisory.AffectedResolution.Components").
 		Preload("Advisory.AffectedCPEList").
 		Preload("References")
 

--- a/fetcher/redhat/redhat.go
+++ b/fetcher/redhat/redhat.go
@@ -42,7 +42,7 @@ func FetchFiles(versions []string) (map[string][]util.FetchResult, error) {
 			}
 			results[v] = rs
 
-			rs, err = fetchOVALv2([]string{v, fmt.Sprintf("%s-extras", v), fmt.Sprintf("%s-supplementary", v), fmt.Sprintf("%s-els", v)})
+			rs, err = fetchOVALv2([]string{fmt.Sprintf("%s-including-unpatched", v), fmt.Sprintf("%s-extras-including-unpatched", v), fmt.Sprintf("%s-supplementary", v), fmt.Sprintf("%s-els", v)})
 			if err != nil {
 				return nil, xerrors.Errorf("Failed to fetch OVALv2. err: %w", err)
 			}
@@ -54,7 +54,7 @@ func FetchFiles(versions []string) (map[string][]util.FetchResult, error) {
 			}
 			results[v] = rs
 
-			rs, err = fetchOVALv2([]string{v, fmt.Sprintf("%s-extras", v), fmt.Sprintf("%s-supplementary", v)})
+			rs, err = fetchOVALv2([]string{fmt.Sprintf("%s-including-unpatched", v), fmt.Sprintf("%s-extras-including-unpatched", v), fmt.Sprintf("%s-supplementary", v)})
 			if err != nil {
 				return nil, xerrors.Errorf("Failed to fetch OVALv2. err: %w", err)
 			}
@@ -66,7 +66,7 @@ func FetchFiles(versions []string) (map[string][]util.FetchResult, error) {
 			}
 			results[v] = rs
 
-			rs, err = fetchOVALv2([]string{v})
+			rs, err = fetchOVALv2([]string{fmt.Sprintf("%s-including-unpatched", v)})
 			if err != nil {
 				return nil, xerrors.Errorf("Failed to fetch OVALv2. err: %w", err)
 			}
@@ -77,7 +77,7 @@ func FetchFiles(versions []string) (map[string][]util.FetchResult, error) {
 				break
 			}
 
-			rs, err := fetchOVALv2([]string{v})
+			rs, err := fetchOVALv2([]string{fmt.Sprintf("%s-including-unpatched", v)})
 			if err != nil {
 				return nil, xerrors.Errorf("Failed to fetch OVALv2. err: %w", err)
 			}

--- a/models/models.go
+++ b/models/models.go
@@ -53,7 +53,7 @@ type Package struct {
 	Name            string `gorm:"index:idx_packages_name"` // If the type:text, varchar(255) is specified, MySQL overflows and gives an error. No problem in GORMv2. (https://github.com/go-gorm/mysql/tree/15e2cbc6fd072be99215a82292e025dab25e2e16#configuration)
 	Version         string `gorm:"type:varchar(255)"`       // affected earlier than this version
 	Arch            string `gorm:"type:varchar(255)"`       // Used for Amazon Linux, Oracle Linux and Fedora
-	NotFixedYet     bool   // Ubuntu Only
+	NotFixedYet     bool   // Used for RedHat, Ubuntu
 	ModularityLabel string `gorm:"type:varchar(255)"` // RHEL 8 or later only
 }
 
@@ -75,6 +75,7 @@ type Advisory struct {
 	Severity           string `gorm:"type:varchar(255)"`
 	Cves               []Cve
 	Bugzillas          []Bugzilla
+	AffectedResolution []Resolution
 	AffectedCPEList    []Cpe
 	AffectedRepository string `gorm:"type:varchar(255)"` // Amazon Linux 2 Only
 	Issued             time.Time
@@ -103,6 +104,23 @@ type Bugzilla struct {
 	BugzillaID string `gorm:"type:varchar(255)"`
 	URL        string `gorm:"type:varchar(255)"`
 	Title      string `gorm:"type:varchar(255)"`
+}
+
+// Resolution : >definitions>definition>metadata>advisory>affected>resolution
+type Resolution struct {
+	ID         uint `gorm:"primary_key" json:"-"`
+	AdvisoryID uint `gorm:"index:idx_resolution_advisory_id" json:"-" xml:"-"`
+
+	State      string `gorm:"type:varchar(255)"`
+	Components []Component
+}
+
+// Component : >definitions>definition>metadata>advisory>affected>resolution>component
+type Component struct {
+	ID           uint `gorm:"primary_key" json:"-"`
+	ResolutionID uint `gorm:"index:idx_component_resolution_id" json:"-" xml:"-"`
+
+	Component string `gorm:"type:varchar(255)"`
 }
 
 // Cpe : >definitions>definition>metadata>advisory>affected_cpe_list

--- a/models/redhat/redhat_test.go
+++ b/models/redhat/redhat_test.go
@@ -253,6 +253,48 @@ func TestWalkRedHat(t *testing.T) {
 				},
 			},
 		},
+		{
+			version: "8",
+			cri: Criteria{
+				Criterias: []Criteria{
+					{
+						Criterias: []Criteria{
+							{
+								Criterias: []Criteria{
+									{
+										Criterias: []Criteria{
+											{
+												Criterions: []Criterion{
+													{Comment: "python2 is installed"},
+													{Comment: "python2 is signed with Red Hat redhatrelease2 key"},
+												},
+											},
+										},
+									},
+								},
+								Criterions: []Criterion{
+									{Comment: "Module inkscape:flatpak is enabled"},
+								},
+							},
+						},
+						Criterions: []Criterion{
+							{Comment: "Red Hat Enterprise Linux 8 is installed"},
+							{Comment: "Red Hat CoreOS 4 is installed"},
+						},
+					},
+				},
+				Criterions: []Criterion{
+					{Comment: "Red Hat Enterprise Linux must be installed"},
+				},
+			},
+			expected: []models.Package{
+				{
+					Name:            "python2",
+					ModularityLabel: "inkscape:flatpak",
+					NotFixedYet:     true,
+				},
+			},
+		},
 	}
 
 	for i, tt := range tests {

--- a/models/redhat/types.go
+++ b/models/redhat/types.go
@@ -110,7 +110,7 @@ type Bugzilla struct {
 
 // AffectedPkgs : >definitions>definition>metadata>advisory>affected
 type AffectedPkgs struct {
-	Resolution struct {
+	Resolution []struct {
 		State     string   `xml:"state,attr"`
 		Component []string `xml:"component"`
 	} `xml:"resolution"`


### PR DESCRIPTION
# What did you implement:

Red Hat OVALv2 provides OVALs that contains unpatched definitions. 
This PR supports those OVAL.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## before
```console
$ goval-dictionary fetch redhat 8
$ goval-dictionary select --by-package redhat 8 "vim-common" | grep "oval:com.redhat.cve:def"
$
```

## after
```console
$ goval-dictionary fetch redhat 8
$ goval-dictionary select --by-package redhat 8 "vim-common" | grep "oval:com.redhat.cve:def"
    DefinitionID: "oval:com.redhat.cve:def:20222819",
    ...
$
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

