### PR TITLE
fix(fetch/oracle): collect modularity label

### DIFF
--- a/models/oracle/oracle_test.go
+++ b/models/oracle/oracle_test.go
@@ -1,0 +1,646 @@
+package oracle
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/vulsio/goval-dictionary/models"
+)
+
+func Test_collectOraclePacks(t *testing.T) {
+	type args struct {
+		cri Criteria
+	}
+	tests := []struct {
+		name string
+		args args
+		want []distroPackage
+	}{
+		{
+			name: "single ver and single arch",
+			args: args{
+				cri: Criteria{
+					Operator:   "AND",
+					Criterions: []Criterion{{Comment: "Oracle Linux 8 is installed"}},
+					Criterias: []Criteria{
+						{
+							Operator:   "AND",
+							Criterions: []Criterion{{Comment: "Oracle Linux arch is x86_64"}},
+							Criterias: []Criteria{
+								{
+									Operator: "OR",
+									Criterias: []Criteria{
+										{
+											Operator: "AND",
+											Criterions: []Criterion{
+												{Comment: "kernel-uek-container is earlier than 0:5.4.17-2136.324.5.3.el8"},
+												{Comment: "kernel-uek-container is signed with the Oracle Linux 8 key"},
+											},
+										},
+										{
+											Operator: "AND",
+											Criterions: []Criterion{
+												{Comment: "kernel-uek-container-debug is earlier than 0:5.4.17-2136.324.5.3.el8"},
+												{Comment: "kernel-uek-container-debug is signed with the Oracle Linux 8 key"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []distroPackage{
+				{
+					osVer: "8",
+					pack: models.Package{
+						Name:    "kernel-uek-container",
+						Version: "0:5.4.17-2136.324.5.3.el8",
+						Arch:    "x86_64",
+					},
+				},
+				{
+					osVer: "8",
+					pack: models.Package{
+						Name:    "kernel-uek-container-debug",
+						Version: "0:5.4.17-2136.324.5.3.el8",
+						Arch:    "x86_64",
+					},
+				},
+			},
+		},
+		{
+			name: "single ver and multiple arch",
+			args: args{
+				cri: Criteria{
+					Operator:   "AND",
+					Criterions: []Criterion{{Comment: "Oracle Linux 9 is installed"}},
+					Criterias: []Criteria{
+						{
+							Operator: "OR",
+							Criterias: []Criteria{
+								{
+									Operator:   "AND",
+									Criterions: []Criterion{{Comment: "Oracle Linux arch is aarch64"}},
+									Criterias: []Criteria{
+										{
+											Operator: "OR",
+											Criterias: []Criteria{
+												{
+													Operator: "AND",
+													Criterions: []Criterion{
+														{Comment: "osbuild is earlier than 0:81-1.el9"},
+														{Comment: "osbuild is signed with the Oracle Linux 9 key"},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Operator:   "AND",
+									Criterions: []Criterion{{Comment: "Oracle Linux arch is x86_64"}},
+									Criterias: []Criteria{
+										{
+											Operator: "OR",
+											Criterias: []Criteria{
+												{
+													Operator: "AND",
+													Criterions: []Criterion{
+														{Comment: "osbuild is earlier than 0:81-1.el9"},
+														{Comment: "osbuild is signed with the Oracle Linux 9 key"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []distroPackage{
+				{
+					osVer: "9",
+					pack: models.Package{
+						Name:    "osbuild",
+						Version: "0:81-1.el9",
+						Arch:    "aarch64",
+					},
+				},
+				{
+					osVer: "9",
+					pack: models.Package{
+						Name:    "osbuild",
+						Version: "0:81-1.el9",
+						Arch:    "x86_64",
+					},
+				},
+			},
+		},
+		{
+			name: "multiple ver and single arch",
+			args: args{
+				cri: Criteria{
+					Operator: "OR",
+					Criterias: []Criteria{
+						{
+							Operator:   "AND",
+							Criterions: []Criterion{{Comment: "Oracle Linux 6 is installed"}},
+							Criterias: []Criteria{
+								{
+									Operator:   "AND",
+									Criterions: []Criterion{{Comment: "Oracle Linux arch is x86_64"}},
+									Criterias: []Criteria{
+										{
+											Operator: "OR",
+											Criterias: []Criteria{
+												{
+													Operator: "AND",
+													Criterions: []Criterion{
+														{Comment: "kernel-uek is earlier than 0:3.8.13-118.17.4.el6uek"},
+														{Comment: "kernel-uek is signed with the Oracle Linux 6 key"},
+													},
+												},
+												{
+													Operator: "AND",
+													Criterions: []Criterion{
+														{Comment: "kernel-uek-debug is earlier than 0:3.8.13-118.17.4.el6uek"},
+														{Comment: "kernel-uek-debug is signed with the Oracle Linux 6 key"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Operator:   "AND",
+							Criterions: []Criterion{{Comment: "Oracle Linux 7 is installed"}},
+							Criterias: []Criteria{
+								{
+									Operator:   "AND",
+									Criterions: []Criterion{{Comment: "Oracle Linux arch is x86_64"}},
+									Criterias: []Criteria{
+										{
+											Operator: "OR",
+											Criterias: []Criteria{
+												{
+													Operator: "AND",
+													Criterions: []Criterion{
+														{Comment: "kernel-uek is earlier than 0:3.8.13-118.17.4.el7uek"},
+														{Comment: "kernel-uek is signed with the Oracle Linux 7 key"},
+													},
+												},
+												{
+													Operator: "AND",
+													Criterions: []Criterion{
+														{Comment: "kernel-uek-debug is earlier than 0:3.8.13-118.17.4.el7uek"},
+														{Comment: "kernel-uek-debug is signed with the Oracle Linux 7 key"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []distroPackage{
+				{
+					osVer: "6",
+					pack: models.Package{
+						Name:    "kernel-uek",
+						Version: "0:3.8.13-118.17.4.el6uek",
+						Arch:    "x86_64",
+					},
+				},
+				{
+					osVer: "6",
+					pack: models.Package{
+						Name:    "kernel-uek-debug",
+						Version: "0:3.8.13-118.17.4.el6uek",
+						Arch:    "x86_64",
+					},
+				},
+				{
+					osVer: "7",
+					pack: models.Package{
+						Name:    "kernel-uek",
+						Version: "0:3.8.13-118.17.4.el7uek",
+						Arch:    "x86_64",
+					},
+				},
+				{
+					osVer: "7",
+					pack: models.Package{
+						Name:    "kernel-uek-debug",
+						Version: "0:3.8.13-118.17.4.el7uek",
+						Arch:    "x86_64",
+					},
+				},
+			},
+		},
+		{
+			name: "multiple ver and multiple arch",
+			args: args{
+				cri: Criteria{
+					Operator: "OR",
+					Criterias: []Criteria{
+						{
+							Operator:   "AND",
+							Criterions: []Criterion{{Comment: "Oracle Linux 5 is installed"}},
+							Criterias: []Criteria{
+								{
+									Operator: "OR",
+									Criterias: []Criteria{
+										{
+											Operator:   "AND",
+											Criterions: []Criterion{{Comment: "Oracle Linux arch is x86_64"}},
+											Criterias: []Criteria{
+												{
+													Operator: "OR",
+													Criterias: []Criteria{
+														{
+															Operator: "AND",
+															Criterions: []Criterion{
+																{Comment: "kernel-uek is earlier than 0:2.6.39-400.294.6.el5uek"},
+																{Comment: "kernel-uek is signed with the Oracle Linux 5 key"},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Operator: "OR",
+									Criterias: []Criteria{
+										{
+											Operator:   "AND",
+											Criterions: []Criterion{{Comment: "Oracle Linux arch is i386"}},
+											Criterias: []Criteria{
+												{
+													Operator: "OR",
+													Criterias: []Criteria{
+														{
+															Operator: "AND",
+															Criterions: []Criterion{
+																{Comment: "kernel-uek is earlier than 0:2.6.39-400.294.6.el5uek"},
+																{Comment: "kernel-uek is signed with the Oracle Linux 5 key"},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Operator:   "AND",
+							Criterions: []Criterion{{Comment: "Oracle Linux 6 is installed"}},
+							Criterias: []Criteria{
+								{
+									Operator: "OR",
+									Criterias: []Criteria{
+										{
+											Operator:   "AND",
+											Criterions: []Criterion{{Comment: "Oracle Linux arch is x86_64"}},
+											Criterias: []Criteria{
+												{
+													Operator: "OR",
+													Criterias: []Criteria{
+														{
+															Operator: "AND",
+															Criterions: []Criterion{
+																{Comment: "kernel-uek is earlier than 0:2.6.39-400.294.6.el6uek"},
+																{Comment: "kernel-uek is signed with the Oracle Linux 6 key"},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Operator: "OR",
+									Criterias: []Criteria{
+										{
+											Operator:   "AND",
+											Criterions: []Criterion{{Comment: "Oracle Linux arch is i386"}},
+											Criterias: []Criteria{
+												{
+													Operator: "OR",
+													Criterias: []Criteria{
+														{
+															Operator: "AND",
+															Criterions: []Criterion{
+																{Comment: "kernel-uek is earlier than 0:2.6.39-400.294.6.el6uek"},
+																{Comment: "kernel-uek is signed with the Oracle Linux 6 key"},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []distroPackage{
+				{
+					osVer: "5",
+					pack: models.Package{
+						Name:    "kernel-uek",
+						Version: "0:2.6.39-400.294.6.el5uek",
+						Arch:    "x86_64",
+					},
+				},
+				{
+					osVer: "5",
+					pack: models.Package{
+						Name:    "kernel-uek",
+						Version: "0:2.6.39-400.294.6.el5uek",
+						Arch:    "i386",
+					},
+				},
+				{
+					osVer: "6",
+					pack: models.Package{
+						Name:    "kernel-uek",
+						Version: "0:2.6.39-400.294.6.el6uek",
+						Arch:    "x86_64",
+					},
+				},
+				{
+					osVer: "6",
+					pack: models.Package{
+						Name:    "kernel-uek",
+						Version: "0:2.6.39-400.294.6.el6uek",
+						Arch:    "i386",
+					},
+				},
+			},
+		},
+		{
+			name: "single modularitylabel",
+			args: args{
+				cri: Criteria{
+					Operator:   "AND",
+					Criterions: []Criterion{{Comment: "Oracle Linux 8 is installed"}},
+					Criterias: []Criteria{
+						{
+							Operator: "OR",
+							Criterias: []Criteria{
+								{
+									Operator:   "AND",
+									Criterions: []Criterion{{Comment: "Oracle Linux arch is aarch64"}},
+									Criterias: []Criteria{
+										{
+											Operator:   "AND",
+											Criterions: []Criterion{{Comment: "Module container-tools:ol8 is enabled"}},
+											Criterias: []Criteria{
+												{
+													Operator: "OR",
+													Criterias: []Criteria{
+														{
+															Criterions: []Criterion{
+																{Comment: "runc is earlier than 0:1.0.0-55.rc5.dev.git2abd837.module+el8.0.0+5215+77f672ad"},
+																{Comment: "runc is signed with the Oracle Linux 8 key"},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Operator:   "AND",
+									Criterions: []Criterion{{Comment: "Oracle Linux arch is x86_64"}},
+									Criterias: []Criteria{
+										{
+											Operator:   "AND",
+											Criterions: []Criterion{{Comment: "Module container-tools:ol8 is enabled"}},
+											Criterias: []Criteria{
+												{
+													Operator: "OR",
+													Criterias: []Criteria{
+														{
+															Criterions: []Criterion{
+																{Comment: "runc is earlier than 0:1.0.0-55.rc5.dev.git2abd837.module+el8.0.0+5215+77f672ad"},
+																{Comment: "runc is signed with the Oracle Linux 8 key"},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []distroPackage{
+				{
+					osVer: "8",
+					pack: models.Package{
+						Name:            "runc",
+						Version:         "0:1.0.0-55.rc5.dev.git2abd837.module+el8.0.0+5215+77f672ad",
+						Arch:            "aarch64",
+						ModularityLabel: "container-tools:ol8",
+					},
+				},
+				{
+					osVer: "8",
+					pack: models.Package{
+						Name:            "runc",
+						Version:         "0:1.0.0-55.rc5.dev.git2abd837.module+el8.0.0+5215+77f672ad",
+						Arch:            "x86_64",
+						ModularityLabel: "container-tools:ol8",
+					},
+				},
+			},
+		},
+		{
+			name: "multiple modularitylabel",
+			args: args{
+				cri: Criteria{
+					Operator:   "AND",
+					Criterions: []Criterion{{Comment: "Oracle Linux 8 is installed"}},
+					Criterias: []Criteria{
+						{
+							Operator: "OR",
+							Criterias: []Criteria{
+								{
+									Operator:   "AND",
+									Criterions: []Criterion{{Comment: "Oracle Linux arch is x86_64"}},
+									Criterias: []Criteria{
+										{
+											Operator: "OR",
+											Criterias: []Criteria{
+												{
+													Operator:   "AND",
+													Criterions: []Criterion{{Comment: "Module virt:ol is enabled"}},
+													Criterias: []Criteria{
+														{
+															Operator: "OR",
+															Criterias: []Criteria{
+																{
+																	Operator: "AND",
+																	Criterions: []Criterion{
+																		{Comment: "libvirt is earlier than 0:4.5.0-35.0.1.module+el8.1.0+5378+c5e0f4d7"},
+																		{Comment: "libvirt is signed with the Oracle Linux 8 key"},
+																	},
+																},
+															},
+														},
+													},
+												},
+												{
+													Operator:   "AND",
+													Criterions: []Criterion{{Comment: "Module virt-devel:ol is enabled"}},
+													Criterias: []Criteria{
+														{
+															Operator: "AND",
+															Criterions: []Criterion{
+																{Comment: "qemu-kvm-tests is earlier than 15:2.12.0-88.0.1.module+el8.1.0+5378+c5e0f4d7"},
+																{Comment: "qemu-kvm-tests is signed with the Oracle Linux 8 key"},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []distroPackage{
+				{
+					osVer: "8",
+					pack: models.Package{
+						Name:            "libvirt",
+						Version:         "0:4.5.0-35.0.1.module+el8.1.0+5378+c5e0f4d7",
+						Arch:            "x86_64",
+						ModularityLabel: "virt:ol",
+					},
+				},
+				{
+					osVer: "8",
+					pack: models.Package{
+						Name:            "qemu-kvm-tests",
+						Version:         "15:2.12.0-88.0.1.module+el8.1.0+5378+c5e0f4d7",
+						Arch:            "x86_64",
+						ModularityLabel: "virt-devel:ol",
+					},
+				},
+			},
+		},
+		{
+			name: "modular package mix with not modular package",
+			args: args{
+				cri: Criteria{
+					Operator:   "AND",
+					Criterions: []Criterion{{Comment: "Oracle Linux 8 is installed"}},
+					Criterias: []Criteria{
+						{
+							Operator: "OR",
+							Criterias: []Criteria{
+								{
+									Operator:   "AND",
+									Criterions: []Criterion{{Comment: "Oracle Linux arch is x86_64"}},
+									Criterias: []Criteria{
+										{
+											Operator: "OR",
+											Criterias: []Criteria{
+												{
+													Operator:   "AND",
+													Criterions: []Criterion{{Comment: "Module name:stream is enabled"}},
+													Criterias: []Criteria{
+														{
+															Operator: "OR",
+															Criterias: []Criteria{
+																{
+																	Operator: "AND",
+																	Criterions: []Criterion{
+																		{Comment: "package is earlier than 0:0.0.1.module+el8.1.0+5378+c5e0f4d7"},
+																		{Comment: "package is signed with the Oracle Linux 8 key"},
+																	},
+																},
+															},
+														},
+													},
+												},
+												{
+													Operator: "AND",
+													Criterias: []Criteria{
+														{
+															Operator: "OR",
+															Criterias: []Criteria{
+																{
+																	Operator: "AND",
+																	Criterions: []Criterion{
+																		{Comment: "package is earlier than 0.0.1.el8"},
+																		{Comment: "package is signed with the Oracle Linux 8 key"},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []distroPackage{
+				{
+					osVer: "8",
+					pack: models.Package{
+						Name:            "package",
+						Version:         "0:0.0.1.module+el8.1.0+5378+c5e0f4d7",
+						Arch:            "x86_64",
+						ModularityLabel: "name:stream",
+					},
+				},
+				{
+					osVer: "8",
+					pack: models.Package{
+						Name:    "package",
+						Version: "0.0.1.el8",
+						Arch:    "x86_64",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := collectOraclePacks(tt.args.cri); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("collectOraclePacks() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What did you implement:
Like Red Hat, Oracle also has vulnerabilities defined for modular packages, and it is necessary to collect modularity labels. This PR will collect modularity labels.

```console
$ curl -s https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2 | bzip2 --decompress | xmllint --format - | grep -A50 "oval:com.oracle.elsa:def:20190975"
    <definition id="oval:com.oracle.elsa:def:20190975" version="501" class="patch">
      <metadata>
        <title>
ELSA-2019-0975: container-tools:rhel8 security and bug fix update (IMPORTANT)
</title>
        <affected family="unix">
          <platform>Oracle Linux 8</platform>
        </affected>
        <reference source="elsa" ref_id="ELSA-2019-0975" ref_url="https://linux.oracle.com/errata/ELSA-2019-0975.html"/>
        <reference source="CVE" ref_id="CVE-2019-5736" ref_url="https://linux.oracle.com/cve/CVE-2019-5736.html"/>
        <description>
container-selinux
[2:2.94-1.git1e99f1d]
- Resolves: #1690286 - bump to v2.94
- Resolves: #1693806, #1689255

[2:2.89-1.git2521d0d]
- bump to v2.89

runc
[1.0.0-55.rc5.dev.git2abd837]
- Resolves: CVE-2019-5736

</description>
        <!--
 ~~~~~~~~~~~~~~~~~~~~   advisory details   ~~~~~~~~~~~~~~~~~~~ 
-->
        <advisory>
          <severity>IMPORTANT</severity>
          <rights>Copyright 2019 Oracle, Inc.</rights>
          <issued date="2019-07-30"/>
          <cve href="https://linux.oracle.com/cve/CVE-2019-5736.html">CVE-2019-5736</cve>
        </advisory>
      </metadata>
      <criteria operator="AND">
        <criterion test_ref="oval:com.oracle.elsa:tst:20190975001" comment="Oracle Linux 8 is installed"/>
        <criteria operator="OR">
          <criteria operator="AND">
            <criterion test_ref="oval:com.oracle.elsa:tst:20190975002" comment="Oracle Linux arch is aarch64"/>
            <criteria operator="AND">
              <criterion test_ref="oval:com.oracle.elsa:tst:20190975003" comment="Module container-tools:ol8 is enabled"/>
              <criteria operator="OR">
                <criteria operator="AND">
                  <criterion test_ref="oval:com.oracle.elsa:tst:20190975004" comment="buildah is earlier than 0:1.5-3.0.1.gite94b4f9.module+el8.0.0+5215+77f672ad"/>
                  <criterion test_ref="oval:com.oracle.elsa:tst:20190975005" comment="buildah is signed with the Oracle Linux 8 key"/>
                </criteria>
                <criteria operator="AND">
                  <criterion test_ref="oval:com.oracle.elsa:tst:20190975006" comment="container-selinux is earlier than 2:2.94-1.git1e99f1d.module+el8.0.0+5215+77f672ad"/>
                  <criterion test_ref="oval:com.oracle.elsa:tst:20190975007" comment="container-selinux is signed with the Oracle Linux 8 key"/>
                </criteria>
                <criteria operator="AND">
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ goval-dictionary fetch oracle 8
$ sqlite3 oval.sqlite3 "SELECT definitions.definition_id, packages.name, packages.version, packages.arch, packages.modularity_label FROM definitions JOIN packages ON packages.definition_id = definitions.id WHERE definitions.definition_id = 'oval:com.oracle.elsa:def:20190975';"
oval:com.oracle.elsa:def:20190975|buildah|0:1.5-3.0.1.gite94b4f9.module+el8.0.0+5215+77f672ad|aarch64|
oval:com.oracle.elsa:def:20190975|container-selinux|2:2.94-1.git1e99f1d.module+el8.0.0+5215+77f672ad|aarch64|
oval:com.oracle.elsa:def:20190975|containernetworking-plugins|0:0.7.4-3.git9ebe139.module+el8.0.0+5215+77f672ad|aarch64|
oval:com.oracle.elsa:def:20190975|containers-common|1:0.1.32-3.0.2.git1715c90.module+el8.0.0+5215+77f672ad|aarch64|
oval:com.oracle.elsa:def:20190975|fuse-overlayfs|0:0.3-2.module+el8.0.0+5215+77f672ad|aarch64|
oval:com.oracle.elsa:def:20190975|oci-systemd-hook|1:0.1.15-2.git2d0b8a3.module+el8.0.0+5215+77f672ad|aarch64|
oval:com.oracle.elsa:def:20190975|oci-umount|2:2.3.4-2.git87f9237.module+el8.0.0+5215+77f672ad|aarch64|
oval:com.oracle.elsa:def:20190975|podman|0:1.0.0-2.0.1.git921f98f.module+el8.0.0+5215+77f672ad|aarch64|
oval:com.oracle.elsa:def:20190975|podman-docker|0:1.0.0-2.0.1.git921f98f.module+el8.0.0+5215+77f672ad|aarch64|
oval:com.oracle.elsa:def:20190975|runc|0:1.0.0-55.rc5.dev.git2abd837.module+el8.0.0+5215+77f672ad|aarch64|
oval:com.oracle.elsa:def:20190975|skopeo|1:0.1.32-3.0.2.git1715c90.module+el8.0.0+5215+77f672ad|aarch64|
oval:com.oracle.elsa:def:20190975|slirp4netns|0:0.1-2.dev.gitc4e1bc5.module+el8.0.0+5215+77f672ad|aarch64|
oval:com.oracle.elsa:def:20190975|buildah|0:1.5-3.0.1.gite94b4f9.module+el8.0.0+5215+77f672ad|x86_64|
oval:com.oracle.elsa:def:20190975|container-selinux|2:2.94-1.git1e99f1d.module+el8.0.0+5215+77f672ad|x86_64|
oval:com.oracle.elsa:def:20190975|containernetworking-plugins|0:0.7.4-3.git9ebe139.module+el8.0.0+5215+77f672ad|x86_64|
oval:com.oracle.elsa:def:20190975|containers-common|1:0.1.32-3.0.2.git1715c90.module+el8.0.0+5215+77f672ad|x86_64|
oval:com.oracle.elsa:def:20190975|fuse-overlayfs|0:0.3-2.module+el8.0.0+5215+77f672ad|x86_64|
oval:com.oracle.elsa:def:20190975|oci-systemd-hook|1:0.1.15-2.git2d0b8a3.module+el8.0.0+5215+77f672ad|x86_64|
oval:com.oracle.elsa:def:20190975|oci-umount|2:2.3.4-2.git87f9237.module+el8.0.0+5215+77f672ad|x86_64|
oval:com.oracle.elsa:def:20190975|podman|0:1.0.0-2.0.1.git921f98f.module+el8.0.0+5215+77f672ad|x86_64|
oval:com.oracle.elsa:def:20190975|podman-docker|0:1.0.0-2.0.1.git921f98f.module+el8.0.0+5215+77f672ad|x86_64|
oval:com.oracle.elsa:def:20190975|runc|0:1.0.0-55.rc5.dev.git2abd837.module+el8.0.0+5215+77f672ad|x86_64|
oval:com.oracle.elsa:def:20190975|skopeo|1:0.1.32-3.0.2.git1715c90.module+el8.0.0+5215+77f672ad|x86_64|
oval:com.oracle.elsa:def:20190975|slirp4netns|0:0.1-2.dev.gitc4e1bc5.module+el8.0.0+5215+77f672ad|x86_64|
```

## after
```console
$ goval-dictionary fetch oracle 8
$ sqlite3 oval.sqlite3 "SELECT definitions.definition_id, packages.name, packages.version, packages.arch, packages.modularity_label FROM definitions JOIN packages ON packages.definition_id = definitions.id WHERE definitions.definition_id = 'oval:com.oracle.elsa:def:20190975';"
oval:com.oracle.elsa:def:20190975|buildah|0:1.5-3.0.1.gite94b4f9.module+el8.0.0+5215+77f672ad|aarch64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|container-selinux|2:2.94-1.git1e99f1d.module+el8.0.0+5215+77f672ad|aarch64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|containernetworking-plugins|0:0.7.4-3.git9ebe139.module+el8.0.0+5215+77f672ad|aarch64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|containers-common|1:0.1.32-3.0.2.git1715c90.module+el8.0.0+5215+77f672ad|aarch64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|fuse-overlayfs|0:0.3-2.module+el8.0.0+5215+77f672ad|aarch64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|oci-systemd-hook|1:0.1.15-2.git2d0b8a3.module+el8.0.0+5215+77f672ad|aarch64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|oci-umount|2:2.3.4-2.git87f9237.module+el8.0.0+5215+77f672ad|aarch64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|podman|0:1.0.0-2.0.1.git921f98f.module+el8.0.0+5215+77f672ad|aarch64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|podman-docker|0:1.0.0-2.0.1.git921f98f.module+el8.0.0+5215+77f672ad|aarch64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|runc|0:1.0.0-55.rc5.dev.git2abd837.module+el8.0.0+5215+77f672ad|aarch64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|skopeo|1:0.1.32-3.0.2.git1715c90.module+el8.0.0+5215+77f672ad|aarch64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|slirp4netns|0:0.1-2.dev.gitc4e1bc5.module+el8.0.0+5215+77f672ad|aarch64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|buildah|0:1.5-3.0.1.gite94b4f9.module+el8.0.0+5215+77f672ad|x86_64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|container-selinux|2:2.94-1.git1e99f1d.module+el8.0.0+5215+77f672ad|x86_64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|containernetworking-plugins|0:0.7.4-3.git9ebe139.module+el8.0.0+5215+77f672ad|x86_64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|containers-common|1:0.1.32-3.0.2.git1715c90.module+el8.0.0+5215+77f672ad|x86_64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|fuse-overlayfs|0:0.3-2.module+el8.0.0+5215+77f672ad|x86_64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|oci-systemd-hook|1:0.1.15-2.git2d0b8a3.module+el8.0.0+5215+77f672ad|x86_64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|oci-umount|2:2.3.4-2.git87f9237.module+el8.0.0+5215+77f672ad|x86_64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|podman|0:1.0.0-2.0.1.git921f98f.module+el8.0.0+5215+77f672ad|x86_64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|podman-docker|0:1.0.0-2.0.1.git921f98f.module+el8.0.0+5215+77f672ad|x86_64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|runc|0:1.0.0-55.rc5.dev.git2abd837.module+el8.0.0+5215+77f672ad|x86_64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|skopeo|1:0.1.32-3.0.2.git1715c90.module+el8.0.0+5215+77f672ad|x86_64|container-tools:ol8
oval:com.oracle.elsa:def:20190975|slirp4netns|0:0.1-2.dev.gitc4e1bc5.module+el8.0.0+5215+77f672ad|x86_64|container-tools:ol8
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

