### PR TITLE
feat(db/redis): do not use Arch for Key in Oracle, Amazon, Fedora

### DIFF
--- a/db/redis.go
+++ b/db/redis.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cheggaaa/pb/v3"
@@ -38,9 +39,7 @@ import (
   ┌───┬────────────────────────────────────────────────┬───────────────┬─────────────────────────────────────────────────┐
   │ 1 │ OVAL#$OSFAMILY#$VERSION#PKG#$PACKAGENAME       │ $DEFINITIONID │ TO GET []$DEFINITIONID                          │
   ├───┼────────────────────────────────────────────────┼───────────────┼─────────────────────────────────────────────────┤
-  │ 2 │ OVAL#$OSFAMILY#$VERSION#PKG#$PACKAGENAME#$ARCH │ $DEFINITIONID │ TO GET []$DEFINITIONID for Amazon/Oracle/Fedora │
-  ├───┼────────────────────────────────────────────────┼───────────────┼─────────────────────────────────────────────────┤
-  │ 3 │ OVAL#$OSFAMILY#$VERSION#CVE#$CVEID             │ $DEFINITIONID │ TO GET []$DEFINITIONID                          │
+  │ 2 │ OVAL#$OSFAMILY#$VERSION#CVE#$CVEID             │ $DEFINITIONID │ TO GET []$DEFINITIONID                          │
   └───┴────────────────────────────────────────────────┴───────────────┴─────────────────────────────────────────────────┘
 
 - Hash
@@ -127,56 +126,96 @@ func (r *RedisDriver) GetByPackName(family, osVer, packName, arch string) ([]mod
 	}
 
 	ctx := context.Background()
-	key := fmt.Sprintf(pkgKeyFormat, family, osVer, packName)
-	pkgKeys := []string{}
-	switch family {
-	case c.Amazon, c.Oracle, c.Fedora:
-		// affected packages for Amazon/Oracle/Fedora OVAL needs to consider arch
-		if arch != "" {
-			pkgKeys = append(pkgKeys, fmt.Sprintf("%s#%s", key, arch))
-		} else {
-			dbsize, err := r.conn.DBSize(ctx).Result()
-			if err != nil {
-				return nil, xerrors.Errorf("Failed to DBSize. err: %w", err)
-			}
 
-			var cursor uint64
-			for {
-				var keys []string
-				var err error
-				keys, cursor, err = r.conn.Scan(ctx, cursor, fmt.Sprintf("%s#%s", key, "*"), dbsize/5).Result()
+	defIDs, err := func() ([]string, error) {
+		switch family {
+		case c.Amazon, c.Oracle, c.Fedora:
+			isOld, err := func() (bool, error) {
+				bs, err := r.conn.Get(ctx, fmt.Sprintf(depKeyFormat, family, osVer)).Bytes()
 				if err != nil {
-					return nil, xerrors.Errorf("Failed to Scan. err: %w", err)
+					return false, xerrors.Errorf("Failed to Get %s. err: %w", fmt.Sprintf(depKeyFormat, family, osVer), err)
 				}
-
-				pkgKeys = append(pkgKeys, keys...)
-
-				if cursor == 0 {
-					break
+				var dep map[string]map[string]map[string]struct{}
+				if err := json.Unmarshal(bs, &dep); err != nil {
+					return false, xerrors.Errorf("Failed to Unmarshal JSON. err: %w", err)
 				}
+				for _, def := range dep {
+					for k := range def["packages"] {
+						return strings.Contains(k, "#"), nil // old pattern: <package name>#<archtecture>
+					}
+				}
+				return false, xerrors.Errorf("%s:*:packages is empty", fmt.Sprintf(depKeyFormat, family, osVer))
+			}()
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to check old goval-dictionary redis architecture. err: %w", err)
 			}
-		}
-	default:
-		pkgKeys = append(pkgKeys, key)
-	}
 
-	pipe := r.conn.Pipeline()
-	for _, pkey := range pkgKeys {
-		_ = pipe.SMembers(ctx, pkey)
-	}
-	cmders, err := pipe.Exec(ctx)
+			if isOld {
+				if arch != "" {
+					defIDs, err := r.conn.SMembers(ctx, fmt.Sprintf(pkgKeyFormat, family, osVer, fmt.Sprintf("%s#%s", packName, arch))).Result()
+					if err != nil {
+						return nil, xerrors.Errorf("Failed to SMembers. err: %w", err)
+					}
+					return defIDs, nil
+				}
+				dbsize, err := r.conn.DBSize(ctx).Result()
+				if err != nil {
+					return nil, xerrors.Errorf("Failed to DBSize. err: %w", err)
+				}
+
+				var pkgKeys []string
+				var cursor uint64
+				for {
+					var keys []string
+					var err error
+					keys, cursor, err = r.conn.Scan(ctx, cursor, fmt.Sprintf(pkgKeyFormat, family, osVer, fmt.Sprintf("%s#%s", packName, "*")), dbsize/5).Result()
+					if err != nil {
+						return nil, xerrors.Errorf("Failed to Scan. err: %w", err)
+					}
+
+					pkgKeys = append(pkgKeys, keys...)
+
+					if cursor == 0 {
+						break
+					}
+				}
+
+				pipe := r.conn.Pipeline()
+				for _, pkey := range pkgKeys {
+					_ = pipe.SMembers(ctx, pkey)
+				}
+				cmders, err := pipe.Exec(ctx)
+				if err != nil {
+					return nil, xerrors.Errorf("Failed to exec pipeline. err: %w", err)
+				}
+
+				var defIDs []string
+				for _, cmder := range cmders {
+					result, err := cmder.(*redis.StringSliceCmd).Result()
+					if err != nil {
+						return nil, xerrors.Errorf("Failed to SMembers. err: %w", err)
+					}
+
+					defIDs = append(defIDs, result...)
+				}
+				return defIDs, nil
+			}
+
+			defIDs, err := r.conn.SMembers(ctx, fmt.Sprintf(pkgKeyFormat, family, osVer, packName)).Result()
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to SMembers. err: %w", err)
+			}
+			return defIDs, nil
+		default:
+			defIDs, err := r.conn.SMembers(ctx, fmt.Sprintf(pkgKeyFormat, family, osVer, packName)).Result()
+			if err != nil {
+				return nil, xerrors.Errorf("Failed to SMembers. err: %w", err)
+			}
+			return defIDs, err
+		}
+	}()
 	if err != nil {
-		return nil, xerrors.Errorf("Failed to exec pipeline. err: %w", err)
-	}
-
-	defIDs := []string{}
-	for _, cmder := range cmders {
-		result, err := cmder.(*redis.StringSliceCmd).Result()
-		if err != nil {
-			return nil, xerrors.Errorf("Failed to SMembers. err: %w", err)
-		}
-
-		defIDs = append(defIDs, result...)
+		return nil, xerrors.Errorf("Failed to get Definition IDs. err: %w", err)
 	}
 	if len(defIDs) == 0 {
 		return []models.Definition{}, nil
@@ -196,7 +235,9 @@ func (r *RedisDriver) GetByPackName(family, osVer, packName, arch string) ([]mod
 		if err != nil {
 			return nil, xerrors.Errorf("Failed to restoreDefinition. err: %w", err)
 		}
-		defs = append(defs, def)
+		if len(def.AffectedPacks) > 0 {
+			defs = append(defs, def)
+		}
 	}
 	return defs, nil
 }
@@ -231,7 +272,9 @@ func (r *RedisDriver) GetByCveID(family, osVer, cveID, arch string) ([]models.De
 		if err != nil {
 			return nil, xerrors.Errorf("Failed to restoreDefinition. err: %w", err)
 		}
-		defs = append(defs, def)
+		if len(def.AffectedPacks) > 0 {
+			defs = append(defs, def)
+		}
 	}
 	return defs, nil
 }
@@ -321,18 +364,11 @@ func (r *RedisDriver) InsertOval(root *models.Root) (err error) {
 			}
 
 			for _, pack := range def.AffectedPacks {
-				pkgName := pack.Name
-				switch family {
-				case c.Amazon, c.Oracle, c.Fedora:
-					// affected packages for Amazon/Oracle/Fedora OVAL needs to consider arch
-					pkgName = fmt.Sprintf("%s#%s", pkgName, pack.Arch)
-				}
-
-				_ = pipe.SAdd(ctx, fmt.Sprintf(pkgKeyFormat, family, osVer, pkgName), def.DefinitionID)
-				newDeps[def.DefinitionID]["packages"][pkgName] = struct{}{}
+				_ = pipe.SAdd(ctx, fmt.Sprintf(pkgKeyFormat, family, osVer, pack.Name), def.DefinitionID)
+				newDeps[def.DefinitionID]["packages"][pack.Name] = struct{}{}
 				if _, ok := oldDeps[def.DefinitionID]; ok {
 					if _, ok := oldDeps[def.DefinitionID]["packages"]; ok {
-						delete(oldDeps[def.DefinitionID]["packages"], pkgName)
+						delete(oldDeps[def.DefinitionID]["packages"], pack.Name)
 					}
 				}
 			}

--- a/db/redis.go
+++ b/db/redis.go
@@ -49,11 +49,11 @@ import (
   ┌───┬─────────────────────────────┬───────────────┬───────────┬───────────────────────────────────────────┐
   │ 1 │ OVAL#$OSFAMILY#$VERSION#DEF │ $DEFINITIONID │ $OVALJSON │ TO GET OVALJSON                           │
   ├───┼─────────────────────────────┼───────────────┼───────────┼───────────────────────────────────────────┤
-  │ 2 │ OVAL#FETCHMETA              │   Revision    │   string  │ GET Go-Oval-Disctionary Binary Revision   │
+  │ 2 │ OVAL#FETCHMETA              │   Revision    │   string  │ GET Go-Oval-Dictionary Binary Revision    │
   ├───┼─────────────────────────────┼───────────────┼───────────┼───────────────────────────────────────────┤
-  │ 3 │ OVAL#FETCHMETA              │ SchemaVersion │    uint   │ GET Go-Oval-Disctionary Schema Version    │
+  │ 3 │ OVAL#FETCHMETA              │ SchemaVersion │    uint   │ GET Go-Oval-Dictionary Schema Version     │
   ├───┼─────────────────────────────┼───────────────┼───────────┼───────────────────────────────────────────┤
-  │ 4 │ OVAL#FETCHMETA              │ LastFetchedAt │ time.Time │ GET Go-Oval-Disctionary Last Fetched Time │
+  │ 4 │ OVAL#FETCHMETA              │ LastFetchedAt │ time.Time │ GET Go-Oval-Dictionary Last Fetched Time  │
   └───┴─────────────────────────────┴───────────────┴───────────┴───────────────────────────────────────────┘
 
   **/
@@ -66,7 +66,6 @@ const (
 	pkgKeyFormat          = "OVAL#%s#%s#PKG#%s"
 	depKeyFormat          = "OVAL#%s#%s#DEP"
 	lastModifiedKeyFormat = "OVAL#%s#%s#LASTMODIFIED"
-	fileMetaKey           = "OVAL#FILEMETA"
 	fetchMetaKey          = "OVAL#FETCHMETA"
 )
 


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Oracle, Amazon, and Fedora had Package Name and Arch for Key.
This allows you to find a really related Definition from the affected package and architecture.

```console
$ redis-cli -n 1 KEYS "OVAL#debian#12#PKG#bash"
1) "OVAL#debian#12#PKG#bash"

// It is not known which architectures will be affected!
$ redis-cli -n 1 SMEMBERS "OVAL#debian#12#PKG#bash"
 1) "oval:org.debian:def:155603378603305228310656709111303140715" // Maybe Aarch64 is not affected!
 2) "oval:org.debian:def:104452954611053805468881680603569149504"
 3) "oval:org.debian:def:242327748915839239835482148445959073568"
 ...

$ redis-cli -n 1 KEYS "OVAL#oracle#8#PKG#bash#*"
1) "OVAL#oracle#8#PKG#bash#x86_64"
2) "OVAL#oracle#8#PKG#bash#aarch64"

// This Definition always affects x86_64!
$ redis-cli -n 1 SMEMBERS "OVAL#oracle#8#PKG#bash#x86_64"
1) "oval:com.oracle.elsa:def:20211679" 
```

However, it is only necessary to check that the Arch is listed in the package affected by Definition, even if you do not attach ARCH to the end of Key.

```console
$ redis-cli -n 1 KEYS "OVAL#oracle#8#PKG#bash"

$ redis-cli -n 1 SMEMBERS "OVAL#oracle#8#PKG#bash"

// Only x86_64 and aarch64 are affected!
$ redis-cli -n 1 HGET "OVAL#oracle#8#DEF" "oval:com.oracle.elsa:def:20211679" | jq
{
  "DefinitionID": "oval:com.oracle.elsa:def:20211679",
  "Title": "ELSA-2021-1679:  bash security and bug fix update (LOW)",
  "Description": "[4.4.19-14]\n- Fix hang when limit for nproc is very high\n  Resolves: #1890888\n\n[4.4.19-13]\n- Correctly drop saved UID when effective UID is not equal to its real UID\n  Resolves: #1793943",
  "Advisory": {
    "Severity": "LOW",
    "Cves": [
      {
        "CveID": "CVE-2019-18276",
        "Cvss2": "",
        "Cvss3": "",
        "Cwe": "",
        "Impact": "",
        "Href": "https://linux.oracle.com/cve/CVE-2019-18276.html",
        "Public": ""
      }
    ],
    "Bugzillas": [],
    "AffectedResolution": null,
    "AffectedCPEList": [],
    "AffectedRepository": "",
    "Issued": "1000-01-01T00:00:00Z",
    "Updated": "1000-01-01T00:00:00Z"
  },
  "Debian": null,
  "AffectedPacks": [
    {
      "Name": "bash",
      "Version": "0:4.4.19-14.el8",
      "Arch": "aarch64",
      "NotFixedYet": false,
      "ModularityLabel": ""
    },
    {
      "Name": "bash-doc",
      "Version": "0:4.4.19-14.el8",
      "Arch": "aarch64",
      "NotFixedYet": false,
      "ModularityLabel": ""
    },
    {
      "Name": "bash",
      "Version": "0:4.4.19-14.el8",
      "Arch": "x86_64",
      "NotFixedYet": false,
      "ModularityLabel": ""
    },
    {
      "Name": "bash-doc",
      "Version": "0:4.4.19-14.el8",
      "Arch": "x86_64",
      "NotFixedYet": false,
      "ModularityLabel": ""
    }
  ],
  "References": [
    {
      "Source": "elsa",
      "RefID": "ELSA-2021-1679",
      "RefURL": "https://linux.oracle.com/errata/ELSA-2021-1679.html"
    },
    {
      "Source": "CVE",
      "RefID": "CVE-2019-18276",
      "RefURL": "https://linux.oracle.com/cve/CVE-2019-18276.html"
    }
  ]
}
```

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
## before
```console
$ docker run --rm -d -p 127.0.0.1:6379:6379 redis
$ goval-dictionary fetch oracle 8 --dbtype redis --dbpath "redis://127.0.0.1:6379/1"
$ redis-cli -n 1 dbsize
(integer) 11226

$ goval-dictionary select --by-package oracle 8 "bash" "x86_64" --dbtype redis --dbpath "redis://127.0.0.1:6379/1"
CVE-2019-18276
    {0 0 bash 0:4.4.19-14.el8 x86_64 false }
    {0 0 bash-doc 0:4.4.19-14.el8 x86_64 false }
------------------
...
$ goval-dictionary select --by-package oracle 8 "bash" "i386" --dbtype redis --dbpath "redis://127.0.0.1:6379/1"
------------------
[]models.Definition{}
```

## after
```console
$ docker run --rm -d -p 127.0.0.1:6379:6379 redis
$ goval-dictionary fetch oracle 8 --dbtype redis --dbpath "redis://127.0.0.1:6379/1"
$ redis-cli -n 1 dbsize
(integer) 7902

$ goval-dictionary select --by-package oracle 8 "bash" "x86_64" --dbtype redis --dbpath "redis://127.0.0.1:6379/1"
CVE-2019-18276
    {0 0 bash 0:4.4.19-14.el8 x86_64 false }
    {0 0 bash-doc 0:4.4.19-14.el8 x86_64 false }
------------------
...
$ goval-dictionary select --by-package oracle 8 "bash" "i386" --dbtype redis --dbpath "redis://127.0.0.1:6379/1"
------------------
[]models.Definition{}
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

