### PR TITLE
fix(redhat): proxy setting for redhat OVALv1

### DIFF
--- a/commands/fetch-redhat.go
+++ b/commands/fetch-redhat.go
@@ -3,8 +3,8 @@ package commands
 import (
 	"encoding/xml"
 	"fmt"
-	"os"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 

--- a/commands/fetch-redhat.go
+++ b/commands/fetch-redhat.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"encoding/xml"
 	"fmt"
+	"os"
+	"net/url"
 	"strings"
 	"time"
 
@@ -57,6 +59,15 @@ func fetchRedHat(_ *cobra.Command, args []string) (err error) {
 	// If the fetch fails the first time (without SchemaVersion), the DB needs to be cleaned every time, so insert SchemaVersion.
 	if err := driver.UpsertFetchMeta(fetchMeta); err != nil {
 		return xerrors.Errorf("Failed to upsert FetchMeta to DB. err: %w", err)
+	}
+
+	httpProxy := viper.GetString("http-proxy")
+	if httpProxy != "" {
+		if url.Parse(httpProxy); err != nil {
+			return xerrors.Errorf("Failed to parse proxy url. err: %w", err)
+		}
+		os.Setenv("HTTP_PROXY", httpProxy)
+		os.Setenv("HTTPS_PROXY", httpProxy)
 	}
 
 	results, err := fetcher.FetchFiles(util.Unique(args))


### PR DESCRIPTION
# What did you implement:
When running the "fetch redhat" command with the --http-proxy option, OVALv1 fetch does not refer to the proxy.
This is my first pull request, and I would appreciate it if you could point out any oddities.

Fixes #408

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I have set up a proxy container in a Vagrant environment that can be connected to from a goval-dictionary dev container.
Then I tested if it goes through the proxy by running the fetch redhat command with the --http-proxy option.
The instructions and materials for setting up the test environment are uploaded below, but please note that this is for my environment and may not work as is.
https://github.com/ksawai996/goval-dictionary/tree/ksawai996/dev_proxy/vagrant

fetch redhat with --http-proxy option
```
# goval-dictionary fetch redhat 5 --http-proxy http://10.0.2.15:3128
INFO[07-11|01:46:22] Fetching...                              URL=https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz
INFO[07-11|01:46:25] Fetched                                  File=com.redhat.rhsa-RHEL5-ELS.xml Count=1172 Timestamp=2021-07-20T20:31:14
WARN[07-11|01:46:25] The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue. GitHub=https://github.com/vulsio/goval-dictionary/issues OVAL=https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz/com.redhat.rhsa-RHEL5-ELS.xml Timestamp=2021-07-20T20:31:14
INFO[07-11|01:46:26] Fetched                                  File=com.redhat.rhsa-RHEL5.xml Count=1172 Timestamp=2023-04-05T15:46:45
WARN[07-11|01:46:26] The fetched OVAL has not been updated for 3 days, the OVAL URL may have changed, please register a GitHub issue. GitHub=https://github.com/vulsio/goval-dictionary/issues OVAL=https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz/com.redhat.rhsa-RHEL5.xml Timestamp=2023-04-05T15:46:45
INFO[07-11|01:46:26] Refreshing...                            Family=redhat Version=5
INFO[07-11|01:46:26] Deleting old Definitions... 
1172 / 1172 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 850 p/s
INFO[07-11|01:46:28] Inserting new Definitions... 
1172 / 1172 [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 718 p/s
INFO[07-11|01:46:30] Finish                                   Updated=1172
```

proxy logs
```
1720662390.227   7520 172.18.0.1 TCP_TUNNEL/200 27038154 CONNECT access.redhat.com:443 - HIER_DIRECT/23.46.229.98 -
```

To check if the proxy is referenced during OVALv1 get, I executed the same command after downing the proxy container and got the following results.
```
# goval-dictionary fetch redhat 5 --http-proxy http://10.0.2.15:3128
INFO[07-11|02:16:11] Fetching...                              URL=https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz
Failed to fetch files. err: Failed to fetch OVALv1. err: Failed to get oval v1. err: Get "https://access.redhat.com/security/data/archive/oval_v1_20230706.tar.gz": proxyconnect tcp: dial tcp 10.0.2.15:3128: connect: connection refused
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below


***Is this ready for review?:*** YES 


# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

