### PR TITLE
fix(models/ubuntu): match Canonical's current OVAL status wording

### DIFF
--- a/models/ubuntu/ubuntu.go
+++ b/models/ubuntu/ubuntu.go
@@ -128,7 +128,7 @@ func parseDefinitions(ovalDefs []Definition, tests map[string]dpkgInfoTest) []mo
 			})
 		}
 
-		date := util.ParsedOrDefaultTime([]string{"2006-01-02", "2006-01-02 15:04:05", "2006-01-02 15:04:05 +0000", "2006-01-02 15:04:05 MST"}, d.Advisory.PublicDate)
+		date := util.ParsedOrDefaultTime([]string{"2006-01-02", "2006-01-02 15:04:05", "2006-01-02 15:04:05 +0000", "2006-01-02 15:04:05 MST", time.RFC3339}, d.Advisory.PublicDate)
 
 		def := models.Definition{
 			DefinitionID: d.ID,
@@ -176,21 +176,23 @@ func walkCriterion(cri Criteria, tests map[string]dpkgInfoTest) []models.Package
 			continue
 		}
 
-		if strings.Contains(c.Comment, "is related to the CVE in some way and has been fixed") || // status: not vulnerable(= not affected)
-			strings.Contains(c.Comment, "is affected and may need fixing") { // status: needs-triage
+		if strings.Contains(c.Comment, "is related to the CVE in some way and has been fixed") || // status: not vulnerable(= not affected) (old wording)
+			strings.Contains(c.Comment, "is affected and may need fixing") { // status: needs-triage (old wording)
 			continue
 		}
 
-		if strings.Contains(c.Comment, "is affected and needs fixing") || // status: needed
-			strings.Contains(c.Comment, "is affected, but a decision has been made to defer addressing it") || // status: deferred
-			strings.Contains(c.Comment, "is affected. An update containing the fix has been completed and is pending publication") || // status: pending
-			strings.Contains(c.Comment, "while related to the CVE in some way, a decision has been made to ignore this issue") { // status: ignored
+		if strings.Contains(c.Comment, "is affected and needs fixing") || // status: needed (old wording)
+			strings.Contains(c.Comment, "is affected, but a decision has been made to defer addressing it") || // status: deferred (old wording)
+			strings.Contains(c.Comment, "is affected. An update containing the fix has been completed and is pending publication") || // status: pending (old wording)
+			strings.Contains(c.Comment, "while related to the CVE in some way, a decision has been made to ignore this issue") || // status: ignored (old wording)
+			strings.Contains(c.Comment, "might be affected and may need fixing") { // status: needed/deferred/pending/ignored/needs-triage (current wording; Canonical no longer distinguishes these via comment text, so treat as not fixed yet)
 			pkgs = append(pkgs, models.Package{
 				Name:        t.Name,
 				NotFixedYet: true,
 			})
-		} else if strings.Contains(c.Comment, "was vulnerable but has been fixed") || // status: released
-			strings.Contains(c.Comment, "was vulnerable and has been fixed") { // status: released, only this comment: "firefox package in $RELEASE_NAME was vulnerable and has been fixed, but no release version available for it."
+		} else if strings.Contains(c.Comment, "was vulnerable but has been fixed") || // status: released (old wording)
+			strings.Contains(c.Comment, "was vulnerable and has been fixed") || // status: released (old wording), only this comment: "firefox package in $RELEASE_NAME was vulnerable and has been fixed, but no release version available for it."
+			strings.Contains(c.Comment, "is affected and has been fixed") { // status: released (current wording)
 			pkgs = append(pkgs, models.Package{
 				Name:        t.Name,
 				Version:     t.FixedVersion,

--- a/models/ubuntu/ubuntu_test.go
+++ b/models/ubuntu/ubuntu_test.go
@@ -211,6 +211,50 @@ func TestCollectUbuntuPacks(t *testing.T) {
 				},
 			},
 		},
+		{
+			// current Canonical wording (statuses needed/deferred/pending/ignored/needs-triage are no longer distinguished)
+			cri: Criteria{
+				Criterions: []Criterion{
+					{
+						TestRef: "oval:com.ubuntu.jammy:tst:202662380000000",
+						Comment: "glibc source package in jammy, might be affected and may need fixing.",
+					},
+				},
+			},
+			tests: map[string]dpkgInfoTest{
+				"oval:com.ubuntu.jammy:tst:202662380000000": {Name: "glibc"},
+			},
+			expected: []models.Package{
+				{
+					Name:        "glibc",
+					NotFixedYet: true,
+				},
+			},
+		},
+		{
+			// current Canonical wording for released/fixed status
+			cri: Criteria{
+				Criterions: []Criterion{
+					{
+						TestRef: "oval:com.ubuntu.jammy:tst:202662380000010",
+						Comment: "glibc source package in jammy, is affected and has been fixed (note: '2.35-0ubuntu3.14').",
+					},
+				},
+			},
+			tests: map[string]dpkgInfoTest{
+				"oval:com.ubuntu.jammy:tst:202662380000010": {
+					Name:         "glibc",
+					FixedVersion: "0:2.35-0ubuntu3.14",
+				},
+			},
+			expected: []models.Package{
+				{
+					Name:        "glibc",
+					Version:     "0:2.35-0ubuntu3.14",
+					NotFixedYet: false,
+				},
+			},
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
# What did you implement:

- Canonical changed Ubuntu's OVAL generation pipeline around 2026-06-02, and the free-text status wording inside <criterion comment="..."> no longer matches the strings walkCriterion checks for. In the current live feeds (verified against bionic/focal/jammy/noble), effectively every criterion falls into the else branch, logs "Failed to detect patch status.", and silently drops the package — AffectedPacks ends up empty for most definitions.
- The finer-grained statuses the old wording distinguished (needed / deferred / pending / ignored / needs-triage) have been collapsed by Canonical into a single generic phrase ("might be affected and may need fixing"), so this change treats all of them as NotFixedYet: true, matching how Canonical's own parse_package_status now classifies them (all map to cve_status = "vulnerable").
- Advisory.PublicDate also switched to RFC3339 (2019-10-23T18:15:00Z) instead of the previously accepted space-separated layouts, so Issued/Updated were silently falling back to the year-1000 default for nearly every definition. Added time.RFC3339 to the accepted layouts.
- Old wording patterns are left in place (harmless, and defensive against any reversion or other OVAL variant using the older format).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```bash
./goval-dictionary fetch ubuntu --debug --dbtype=mysql --dbpath='root:password@tcp(localhost:3308)/test?parseTime=true' 14.04 16.04 18.04 20.04 22.04 24.04;
INFO[07-30|20:25:51] Fetching...                              URL=https://security-metadata.canonical.com/oval/oci.com.ubuntu.jammy.cve.oval.xml.bz2
INFO[07-30|20:25:58] Fetching...                              URL=https://security-metadata.canonical.com/oval/oci.com.ubuntu.noble.cve.oval.xml.bz2
INFO[07-30|20:26:02] Fetching...                              URL=https://security-metadata.canonical.com/oval/oci.com.ubuntu.trusty.cve.oval.xml.bz2
INFO[07-30|20:26:05] Fetching...                              URL=https://security-metadata.canonical.com/oval/oci.com.ubuntu.xenial.cve.oval.xml.bz2
INFO[07-30|20:26:08] Fetching...                              URL=https://security-metadata.canonical.com/oval/oci.com.ubuntu.bionic.cve.oval.xml.bz2
INFO[07-30|20:26:10] Fetching...                              URL=https://security-metadata.canonical.com/oval/oci.com.ubuntu.focal.cve.oval.xml.bz2
INFO[07-30|20:26:16] Fetched                                  File=oci.com.ubuntu.jammy.cve.oval.xml.bz2 Count=30427 Timestamp=2026-07-29T13:34:43
INFO[07-30|20:26:16] Refreshing...                            Family=ubuntu Version=22.04
INFO[07-30|20:26:16] Deleting old Definitions...
30421 / 30421 [-----------------------------------------------------------------------------------------] 100.00% 2587 p/s
INFO[07-30|20:26:29] Inserting new Definitions...
30421 / 30421 [------------------------------------------------------------------------------------------] 100.00% 869 p/s
INFO[07-30|20:27:04] Finish                                   Updated=30421
INFO[07-30|20:27:06] Fetched                                  File=oci.com.ubuntu.noble.cve.oval.xml.bz2 Count=27126 Timestamp=2026-07-29T13:07:00
INFO[07-30|20:27:06] Refreshing...                            Family=ubuntu Version=24.04
INFO[07-30|20:27:06] Deleting old Definitions...
27122 / 27122 [-----------------------------------------------------------------------------------------] 100.00% 3490 p/s
INFO[07-30|20:27:15] Inserting new Definitions...
27122 / 27122 [-----------------------------------------------------------------------------------------] 100.00% 1073 p/s
INFO[07-30|20:27:42] Finish                                   Updated=27122
INFO[07-30|20:27:42] Fetched                                  File=oci.com.ubuntu.trusty.cve.oval.xml.bz2 Count=19438 Timestamp=2026-07-29T14:09:43
INFO[07-30|20:27:43] Refreshing...                            Family=ubuntu Version=14.04
INFO[07-30|20:27:43] Deleting old Definitions...
19434 / 19434 [-----------------------------------------------------------------------------------------] 100.00% 9075 p/s
INFO[07-30|20:27:45] Inserting new Definitions...
19434 / 19434 [-----------------------------------------------------------------------------------------] 100.00% 1083 p/s
INFO[07-30|20:28:04] Finish                                   Updated=19434
INFO[07-30|20:28:05] Fetched                                  File=oci.com.ubuntu.xenial.cve.oval.xml.bz2 Count=17656 Timestamp=2026-07-29T14:08:14
INFO[07-30|20:28:05] Refreshing...                            Family=ubuntu Version=16.04
INFO[07-30|20:28:05] Deleting old Definitions...
17651 / 17651 [----------------------------------------------------------------------------------------] 100.00% 10140 p/s
INFO[07-30|20:28:07] Inserting new Definitions...
17651 / 17651 [-----------------------------------------------------------------------------------------] 100.00% 1189 p/s
INFO[07-30|20:28:23] Finish                                   Updated=17651
INFO[07-30|20:28:24] Fetched                                  File=oci.com.ubuntu.bionic.cve.oval.xml.bz2 Count=21480 Timestamp=2026-07-29T14:00:46
INFO[07-30|20:28:25] Refreshing...                            Family=ubuntu Version=18.04
INFO[07-30|20:28:25] Deleting old Definitions...
21474 / 21474 [-----------------------------------------------------------------------------------------] 100.00% 8472 p/s
INFO[07-30|20:28:28] Inserting new Definitions...
21474 / 21474 [-----------------------------------------------------------------------------------------] 100.00% 1289 p/s
INFO[07-30|20:28:45] Finish                                   Updated=21474
INFO[07-30|20:28:47] Fetched                                  File=oci.com.ubuntu.focal.cve.oval.xml.bz2 Count=20429 Timestamp=2026-07-29T13:50:47
INFO[07-30|20:28:47] Refreshing...                            Family=ubuntu Version=20.04
INFO[07-30|20:28:47] Deleting old Definitions...
20423 / 20423 [-----------------------------------------------------------------------------------------] 100.00% 4831 p/s
INFO[07-30|20:28:52] Inserting new Definitions...
20423 / 20423 [-----------------------------------------------------------------------------------------] 100.00% 1133 p/s
INFO[07-30|20:29:10] Finish                                   Updated=20423
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:***  YES

# Reference

* https://git.launchpad.net/ubuntu-cve-tracker

